### PR TITLE
Add support for extracting preview image from Canon CR3 file

### DIFF
--- a/imagemeta.go
+++ b/imagemeta.go
@@ -14,6 +14,7 @@ import (
 	"github.com/evanoberholster/imagemeta/jpeg"
 	"github.com/evanoberholster/imagemeta/meta"
 	"github.com/evanoberholster/imagemeta/png"
+	"github.com/evanoberholster/imagemeta/preview"
 	"github.com/evanoberholster/imagemeta/tiff"
 	"github.com/pkg/errors"
 )
@@ -182,4 +183,38 @@ func DecodePng(r io.ReadSeeker) (exif2.Exif, error) {
 	}
 
 	return ir.Exif, nil
+}
+
+// PreviewCR3 previews a CR3 file from an io.Reader returning preview image binary or an error.
+func PreviewCR3(r io.ReadSeeker) ([]byte, error) {
+	rr := readerPool.Get().(*bufio.Reader)
+	defer readerPool.Put(rr)
+	rr.Reset(r)
+
+	pr := preview.NewPreviewReader(exif2.Logger)
+
+	bmr := isobmff.NewReader(rr)
+	bmr.PreviewImageReader = pr.RenderPreview
+	defer bmr.Close()
+
+	if err := bmr.ReadFTYP(); err != nil {
+		return nil, errors.Wrapf(err, "ReadFtypBox")
+	}
+
+	// moov
+	if err := bmr.ReadMetadata(); err != nil {
+		return nil, err
+	}
+
+	// uuid xpacket
+	if err := bmr.ReadMetadata(); err != nil {
+		return nil, err
+	}
+
+	// uuid preview
+	if err := bmr.ReadMetadata(); err != nil {
+		return nil, err
+	}
+
+	return pr.PreviewImage, nil
 }

--- a/imagemeta.go
+++ b/imagemeta.go
@@ -191,7 +191,7 @@ func PreviewCR3(r io.ReadSeeker) ([]byte, error) {
 	defer readerPool.Put(rr)
 	rr.Reset(r)
 
-	pr := preview.NewPreviewReader(exif2.Logger)
+	pr := preview.NewPreviewReader(preview.Logger)
 
 	bmr := isobmff.NewReader(rr)
 	bmr.PreviewImageReader = pr.RenderPreview

--- a/isobmff/moov.go
+++ b/isobmff/moov.go
@@ -27,6 +27,8 @@ func (r *Reader) ReadMetadata() (err error) {
 	case typeMoov:
 		err = r.readMoovBox(&b)
 		b.close()
+	case typeUUID:
+		err = r.readUUIDBox(&b)
 	default:
 		if logLevelInfo() {
 			logInfo().Object("box", b).Send()

--- a/isobmff/prvw.go
+++ b/isobmff/prvw.go
@@ -1,0 +1,77 @@
+package isobmff
+
+import (
+	"github.com/evanoberholster/imagemeta/meta"
+	"github.com/pkg/errors"
+)
+
+type PRVWBox struct {
+	Size   uint32
+	Width  uint16
+	Height uint16
+}
+
+func (r *Reader) readPreview(b *box) (err error) {
+	inner, err := r.createPRVWBox(b)
+	if err != nil {
+		return errors.Wrapf(err, "ReadPRVWBox")
+	}
+
+	r.prvw, err = parsePreviewBox(&inner)
+	if err != nil {
+		return errors.Wrapf(err, "parsePreviewBox")
+	}
+
+	if r.PreviewImageReader != nil {
+		if err = r.PreviewImageReader(&inner, meta.PreviewHeader(r.prvw)); err != nil {
+			if logLevelError() {
+				logError().Object("box", inner).Err(err).Send()
+			}
+		}
+	}
+
+	return inner.close()
+}
+
+func (r *Reader) createPRVWBox(b *box) (inner box, err error) {
+	_, err = b.Discard(8)
+	if err != nil {
+		return inner, errors.Wrap(ErrBufLength, "readPRVWBoxDiscard")
+	}
+
+	buf, err := b.Peek(8)
+	if err != nil {
+		return inner, errors.Wrap(ErrBufLength, "readPRVWBoxPeek")
+	}
+
+	inner.reader = b.reader
+	inner.outer = b
+	inner.offset = int(b.size) - b.remain + b.offset
+	inner.size = int64(bmffEndian.Uint32(buf[:4]))
+	inner.remain = int(inner.size)
+	inner.boxType = boxTypeFromBuf(buf[4:8])
+
+	return inner, nil
+}
+
+func parsePreviewBox(b *box) (prvw PRVWBox, err error) {
+	if !b.isType(typePRVW) {
+		return prvw, ErrWrongBoxType
+	}
+
+	buf, err := b.Peek(24)
+	if err != nil {
+		return prvw, errors.Wrap(ErrBufLength, "parsePreviewBoxPeek")
+	}
+
+	prvw.Width = bmffEndian.Uint16(buf[14:16])
+	prvw.Height = bmffEndian.Uint16(buf[16:18])
+	prvw.Size = bmffEndian.Uint32(buf[20:24])
+
+	_, err = b.Discard(24)
+	if err != nil {
+		return prvw, errors.Wrap(ErrBufLength, "parsePreviewBoxDiscard")
+	}
+
+	return prvw, nil
+}

--- a/isobmff/reader.go
+++ b/isobmff/reader.go
@@ -34,10 +34,12 @@ type Reader struct {
 	br *bufio.Reader
 
 	ftyp FileTypeBox
+	prvw PRVWBox
 	heic HeicMeta
 
-	ExifReader func(r io.Reader, h meta.ExifHeader) error
-	XMPReader  func(r io.Reader) error
+	ExifReader         func(r io.Reader, h meta.ExifHeader) error
+	XMPReader          func(r io.Reader) error
+	PreviewImageReader func(r io.Reader, h meta.PreviewHeader) error
 
 	offset int
 	rPool  bool

--- a/isobmff/uuid.go
+++ b/isobmff/uuid.go
@@ -11,6 +11,9 @@ var (
 
 	// cr3XPacketUUID is the uuid that corresponds with Canon CR3 xpacket data
 	cr3XPacketUUID = meta.UUIDFromString("be7acfcb-97a9-42e8-9c71-999491e3afac")
+
+	// cr3PreviewUUID is the uuid that corresponds with Canon CR3 Preview Image.
+	cr3PreviewUUID = meta.UUIDFromString("eaf42b5e-1c98-4b88-b9fb-b7dc406e4d16")
 )
 
 func (r *Reader) readUUIDBox(b *box) error {
@@ -34,6 +37,10 @@ func (r *Reader) readUUIDBox(b *box) error {
 		}
 	case cr3MetaBoxUUID:
 		if _, err = readCrxMoovBox(b, r.ExifReader); err != nil {
+			return err
+		}
+	case cr3PreviewUUID:
+		if err = r.readPreview(b); err != nil {
 			return err
 		}
 	default:

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -118,3 +118,9 @@ type XmpHeader struct {
 func NewXMPHeader(offset, length uint32) XmpHeader {
 	return XmpHeader{offset, length}
 }
+
+type PreviewHeader struct {
+	Size   uint32
+	Width  uint16
+	Height uint16
+}

--- a/preview/log.go
+++ b/preview/log.go
@@ -1,0 +1,17 @@
+package preview
+
+import (
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	// Logger is the logger
+	Logger zerolog.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout}).Level(zerolog.PanicLevel).With().Str("package", "preview").Logger()
+)
+
+func (pr *previewReader) logError(err error) *zerolog.Event {
+	return pr.logger.Err(err)
+}

--- a/preview/preview.go
+++ b/preview/preview.go
@@ -35,6 +35,10 @@ func (pr *previewReader) RenderPreview(r io.Reader, h meta.PreviewHeader) error 
 			if err == io.EOF {
 				break
 			}
+			pr.logger.Error().Err(err).
+				Uint32("offset", offset).
+				Uint32("maxOffset", maxOffset).
+				Msgf("error read preview image")
 			return err
 		}
 		if readLength == 0 {

--- a/preview/preview.go
+++ b/preview/preview.go
@@ -1,0 +1,50 @@
+package preview
+
+import (
+	"io"
+
+	"github.com/evanoberholster/imagemeta/meta"
+	"github.com/rs/zerolog"
+)
+
+type previewReader struct {
+	logger zerolog.Logger
+
+	PreviewImage []byte
+}
+
+func NewPreviewReader(l zerolog.Logger) previewReader {
+	ir := previewReader{
+		logger: l,
+	}
+	return ir
+}
+
+func (pr *previewReader) RenderPreview(r io.Reader, h meta.PreviewHeader) error {
+	img := make([]byte, h.Size)
+	offset := uint32(0)
+	maxSize := uint32(2048)
+	for {
+		maxOffset := offset + maxSize
+		if h.Size < maxOffset {
+			maxOffset = h.Size
+		}
+
+		readLength, err := r.Read(img[offset:maxOffset])
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		if readLength == 0 {
+			break
+		}
+
+		offset += uint32(readLength)
+	}
+
+	pr.PreviewImage = img
+
+	return nil
+}

--- a/preview/preview.go
+++ b/preview/preview.go
@@ -35,7 +35,7 @@ func (pr *previewReader) RenderPreview(r io.Reader, h meta.PreviewHeader) error 
 			if err == io.EOF {
 				break
 			}
-			pr.logger.Error().Err(err).
+			pr.logError(err).
 				Uint32("offset", offset).
 				Uint32("maxOffset", maxOffset).
 				Msgf("error read preview image")


### PR DESCRIPTION
Hi, I have added a feature to extract preview image from Canon CR3 file.
The preview file should be stored in the 4th block and its UUID is equal to `eaf42b5e-1c98-4b88-b9fb-b7dc406e4d16` so I just call ReadMetadata function again to process the preview block.
