### PR TITLE
Fix parsing iloc boxes with 0 offsetSize

### DIFF
--- a/isobmff/iloc.go
+++ b/isobmff/iloc.go
@@ -136,6 +136,8 @@ func readIlocHeader(b *box) (ilb itemLocationBox, err error) {
 
 func uintN(size uint8, buf []byte) uint64 {
 	switch size {
+	case 0:
+		return 0
 	case 1:
 		return uint64(buf[0])
 	case 2:


### PR DESCRIPTION
Hi, this fixes parsing https://github.com/link-u/avif-sample-images/blob/master/hato.profile0.8bpc.yuv420.avif

