### PR TITLE
meta/jpeg: fix nextMarker loop, bound metadata scan, add context

### DIFF
--- a/meta/jpeg/jpeg.go
+++ b/meta/jpeg/jpeg.go
@@ -6,6 +6,7 @@
 package jpeg
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -18,18 +19,36 @@ var (
 	ErrNoJPEGMarker      = errors.New("no JPEG Marker")
 	ErrEndOfImage        = errors.New("end of Image")
 	ErrInvalidMarkerSize = errors.New("invalid jpeg marker size")
+	ErrMetadataScanLimit = errors.New("jpeg metadata scan limit exceeded")
 )
+
+// ScanJPEGContext scans a reader for JPEG Image markers with cancellation and
+// scan limits. exifReader and xmpReader are run at their respective positions
+// during the scan.
+//
+// Returns ErrNoJPEGMarker if a JPEG SOF was not found.
+func ScanJPEGContext(ctx context.Context, r io.Reader, exifReader func(r io.Reader, header meta.ExifHeader) error, xmpReader func(r io.Reader) error) (err error) {
+	var readerAt io.ReaderAt
+	if ra, ok := r.(io.ReaderAt); ok {
+		readerAt = ra
+	}
+	return scanJPEG(ctx, r, readerAt, exifReader, xmpReader)
+}
 
 // ScanJPEG scans a reader for JPEG Image markers. exifReader and xmpReader are run at their respective
 // positions during the scan.
 //
 // Returns the error ErrNoJPEGMarker if a JPEG SOF was not found.
 func ScanJPEG(r io.Reader, exifReader func(r io.Reader, header meta.ExifHeader) error, xmpReader func(r io.Reader) error) (err error) {
-	var readerAt io.ReaderAt
-	if ra, ok := r.(io.ReaderAt); ok {
-		readerAt = ra
-	}
-	return scanJPEG(r, readerAt, exifReader, xmpReader)
+	return ScanJPEGContext(context.Background(), r, exifReader, xmpReader)
+}
+
+// ScanJPEGWithReaderAtContext scans JPEG markers using r as the forward stream and
+// readerAt for independent segment reads. readerAt must use the same byte
+// offsets as r. This lets metadata callbacks read from a section without moving
+// the forward JPEG scanner.
+func ScanJPEGWithReaderAtContext(ctx context.Context, r io.Reader, readerAt io.ReaderAt, exifReader func(r io.Reader, header meta.ExifHeader) error, xmpReader func(r io.Reader) error) (err error) {
+	return scanJPEG(ctx, r, readerAt, exifReader, xmpReader)
 }
 
 // ScanJPEGWithReaderAt scans JPEG markers using r as the forward stream and
@@ -37,16 +56,22 @@ func ScanJPEG(r io.Reader, exifReader func(r io.Reader, header meta.ExifHeader) 
 // offsets as r. This lets metadata callbacks read from a section without moving
 // the forward JPEG scanner.
 func ScanJPEGWithReaderAt(r io.Reader, readerAt io.ReaderAt, exifReader func(r io.Reader, header meta.ExifHeader) error, xmpReader func(r io.Reader) error) (err error) {
-	return scanJPEG(r, readerAt, exifReader, xmpReader)
+	return ScanJPEGWithReaderAtContext(context.Background(), r, readerAt, exifReader, xmpReader)
+}
+
+// ScanJPEGWithSourceContext scans JPEG markers from stream and uses source for
+// independent segment reads when source implements io.ReaderAt.
+func ScanJPEGWithSourceContext(ctx context.Context, stream io.Reader, source io.Reader, exifReader func(r io.Reader, header meta.ExifHeader) error, xmpReader func(r io.Reader) error) error {
+	if ra, ok := source.(io.ReaderAt); ok {
+		return ScanJPEGWithReaderAtContext(ctx, stream, ra, exifReader, xmpReader)
+	}
+	return ScanJPEGContext(ctx, stream, exifReader, xmpReader)
 }
 
 // ScanJPEGWithSource scans JPEG markers from stream and uses source for
 // independent segment reads when source implements io.ReaderAt.
 func ScanJPEGWithSource(stream io.Reader, source io.Reader, exifReader func(r io.Reader, header meta.ExifHeader) error, xmpReader func(r io.Reader) error) error {
-	if ra, ok := source.(io.ReaderAt); ok {
-		return ScanJPEGWithReaderAt(stream, ra, exifReader, xmpReader)
-	}
-	return ScanJPEG(stream, exifReader, xmpReader)
+	return ScanJPEGWithSourceContext(context.Background(), stream, source, exifReader, xmpReader)
 }
 
 // ScanMetadata scans a JPEG stream and returns metadata stored directly in JPEG

--- a/meta/jpeg/jpeg_test.go
+++ b/meta/jpeg/jpeg_test.go
@@ -6,10 +6,14 @@ package jpeg
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/evanoberholster/imagemeta/imagetype"
 	"github.com/evanoberholster/imagemeta/meta"
@@ -242,6 +246,62 @@ func TestScanJPEGExtendedXMP(t *testing.T) {
 	}
 }
 
+func TestScanJPEG_nextMarkerNoInfiniteLoop(t *testing.T) {
+	inputs := [][]byte{
+		{0xFF, 0x00},
+		{0xFF, 0xFF},
+	}
+	for _, input := range inputs {
+		name := fmt.Sprintf("%02x_%02x", input[0], input[1])
+		t.Run(name, func(t *testing.T) {
+			done := make(chan error, 1)
+			go func() {
+				done <- ScanJPEG(bytes.NewReader(input), nil, nil)
+			}()
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+			case <-time.After(time.Second):
+				t.Fatal("ScanJPEG hung")
+			}
+		})
+	}
+}
+
+func TestScanJPEG_metadataScanLimit(t *testing.T) {
+	data := make([]byte, 0, 2+maxMetadataScanBytes+1024)
+	data = append(data, 0xFF, byte(markerSOI))
+	data = append(data, bytes.Repeat([]byte{0}, maxMetadataScanBytes+1024)...)
+
+	start := time.Now()
+	err := ScanJPEG(bytes.NewReader(data), nil, nil)
+	if !errors.Is(err, ErrMetadataScanLimit) {
+		t.Fatalf("err = %v, want ErrMetadataScanLimit", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("scan took %v, expected to hit limit quickly", elapsed)
+	}
+}
+
+func TestScanJPEG_contextCancel(t *testing.T) {
+	data := append([]byte{0xFF, byte(markerSOI)}, bytes.Repeat([]byte{0}, 512*1024)...)
+	r := &slowReader{r: bytes.NewReader(data), delay: 5 * time.Millisecond}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := ScanJPEGContext(ctx, r, nil, nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("cancel took %v, expected prompt return", elapsed)
+	}
+}
+
 func TestScanMetadataSyntheticAPPFamilies(t *testing.T) {
 	data := testJPEG(
 		testSegment(markerAPP0, testJFIFPayload(1, 2, 1, 300, 200)),
@@ -451,6 +511,16 @@ type onlyReader struct {
 
 func (r onlyReader) Read(p []byte) (int, error) {
 	return r.r.Read(p)
+}
+
+type slowReader struct {
+	r     io.Reader
+	delay time.Duration
+}
+
+func (s *slowReader) Read(p []byte) (int, error) {
+	time.Sleep(s.delay)
+	return s.r.Read(p)
 }
 
 func testJPEG(segments ...[]byte) []byte {

--- a/meta/jpeg/scanner.go
+++ b/meta/jpeg/scanner.go
@@ -2,6 +2,7 @@ package jpeg
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -10,10 +11,13 @@ import (
 )
 
 const (
-	bufferSize int = 4 * 1024 // 4Kb
+	bufferSize           int = 4 * 1024        // 4Kb
+	maxMetadataScanBytes     = 2 * 1024 * 1024 // 2 MiB metadata scan budget
 )
 
 type jpegReader struct {
+	ctx context.Context
+
 	ExifReader func(r io.Reader, h meta.ExifHeader) error
 	XMPReader  func(r io.Reader) error
 
@@ -44,19 +48,19 @@ var bufferPool = sync.Pool{
 	New: func() interface{} { return bufio.NewReaderSize(nil, bufferSize) },
 }
 
-func scanJPEG(r io.Reader, readerAt io.ReaderAt, exifReader func(r io.Reader, header meta.ExifHeader) error, xmpReader func(r io.Reader) error) (err error) {
-	return scanJPEGWithMetadata(r, readerAt, exifReader, xmpReader, nil)
+func scanJPEG(ctx context.Context, r io.Reader, readerAt io.ReaderAt, exifReader func(r io.Reader, header meta.ExifHeader) error, xmpReader func(r io.Reader) error) (err error) {
+	return scanJPEGWithMetadata(ctx, r, readerAt, exifReader, xmpReader, nil)
 }
 
 func scanMetadata(r io.Reader, readerAt io.ReaderAt) (m Metadata, err error) {
-	err = scanJPEGWithMetadata(r, readerAt, nil, nil, &m)
+	err = scanJPEGWithMetadata(context.Background(), r, readerAt, nil, nil, &m)
 	if finishErr := m.finish(); err == nil {
 		err = finishErr
 	}
 	return m, err
 }
 
-func scanJPEGWithMetadata(r io.Reader, readerAt io.ReaderAt, exifReader func(r io.Reader, header meta.ExifHeader) error, xmpReader func(r io.Reader) error, metadata *Metadata) (err error) {
+func scanJPEGWithMetadata(ctx context.Context, r io.Reader, readerAt io.ReaderAt, exifReader func(r io.Reader, header meta.ExifHeader) error, xmpReader func(r io.Reader) error, metadata *Metadata) (err error) {
 	defer func() {
 		if state := recover(); state != nil {
 			if recoveredErr, ok := state.(error); ok {
@@ -66,6 +70,10 @@ func scanJPEGWithMetadata(r io.Reader, readerAt io.ReaderAt, exifReader func(r i
 			err = fmt.Errorf("jpeg panic: %v", state)
 		}
 	}()
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	var localBuffer bool
 	br, ok := r.(*bufio.Reader)
@@ -79,7 +87,7 @@ func scanJPEGWithMetadata(r io.Reader, readerAt io.ReaderAt, exifReader func(r i
 		br.Reset(r)
 	}
 
-	jr := &jpegReader{br: br, readerAt: readerAt, ExifReader: exifReader, XMPReader: xmpReader, metadata: metadata}
+	jr := &jpegReader{ctx: ctx, br: br, readerAt: readerAt, ExifReader: exifReader, XMPReader: xmpReader, metadata: metadata}
 
 	defer func() {
 		if localBuffer {
@@ -88,7 +96,13 @@ func scanJPEGWithMetadata(r io.Reader, readerAt io.ReaderAt, exifReader func(r i
 		}
 	}()
 
-	for jr.nextMarker() {
+	for {
+		if !jr.abortIfContextDone() {
+			break
+		}
+		if !jr.nextMarker() {
+			break
+		}
 		switch {
 		case isSOFMarker(jr.marker):
 			jr.readSOFMarker()
@@ -142,8 +156,30 @@ func scanJPEGWithMetadata(r io.Reader, readerAt io.ReaderAt, exifReader func(r i
 	return jr.processExtendedXMP()
 }
 
+func (jr *jpegReader) abortIfContextDone() bool {
+	if jr.ctx.Err() != nil {
+		jr.err = jr.ctx.Err()
+		return false
+	}
+	return true
+}
+
+func (jr *jpegReader) abortIfScanLimitExceeded() bool {
+	if jr.discarded > maxMetadataScanBytes {
+		jr.err = ErrMetadataScanLimit
+		return false
+	}
+	return true
+}
+
 func (jr *jpegReader) nextMarker() bool {
 	for jr.err == nil {
+		if !jr.abortIfContextDone() {
+			return false
+		}
+		if !jr.abortIfScanLimitExceeded() {
+			return false
+		}
 		if jr.buf, jr.err = jr.peek(2); jr.err != nil {
 			jr.err = ErrNoJPEGMarker
 			return false
@@ -169,12 +205,24 @@ func (jr *jpegReader) nextMarker() bool {
 				i--
 			}
 			jr.err = jr.discard(i)
+			if jr.err != nil {
+				return false
+			}
+			if !jr.abortIfScanLimitExceeded() {
+				return false
+			}
 			continue
 		}
 
 		if isSOIMarker(jr.buf) {
 			jr.pos++
 			jr.err = jr.discard(2)
+			if jr.err != nil {
+				return false
+			}
+			if !jr.abortIfScanLimitExceeded() {
+				return false
+			}
 			continue
 		}
 		if jr.pos > 0 {
@@ -197,6 +245,9 @@ func (jr *jpegReader) nextMarker() bool {
 				if jr.err != nil {
 					return false
 				}
+				if !jr.abortIfScanLimitExceeded() {
+					return false
+				}
 				continue
 			}
 			peekLen := int(jr.size) + 2
@@ -211,6 +262,15 @@ func (jr *jpegReader) nextMarker() bool {
 				return false
 			}
 			return true
+		}
+
+		// Leading 0xFF without SOI: advance one byte to avoid infinite Peek loop.
+		jr.err = jr.discard(1)
+		if jr.err != nil {
+			return false
+		}
+		if !jr.abortIfScanLimitExceeded() {
+			return false
 		}
 	}
 	return false


### PR DESCRIPTION
I encountered a problem with goroutines not ending when running discover for images in an image gallery application. I traced it to a defect in the imagemeta jpeg scanner. This PR corrects the issue.

---

Malformed JPEG inputs could cause ScanJPEG to spin forever in bufio.Peek when the stream started with 0xFF but not SOI, or to discard unbounded bytes through multi-GB files with no marker bytes. Metadata lives in early APP segments; scanning far beyond the header is never valid extraction.

- discard(1) when pos==0 and byte is 0xFF but not SOI (avoids infinite Peek)
- cap scan budget at 2 MiB via jr.discarded; export ErrMetadataScanLimit
- add ScanJPEGContext, ScanJPEGWithReaderAtContext, ScanJPEGWithSourceContext
- keep existing ScanJPEG* APIs as wrappers using context.Background()
- tests: nextMarker hang, scan limit, context cancellation

Backward compatible at compile time; existing signatures unchanged.