### PR TITLE
Embedded TIFF preview extraction (PreviewTIFF, TIFFPreviews)

### DIFF
--- a/meta/exif/model.go
+++ b/meta/exif/model.go
@@ -13,11 +13,15 @@ import (
 
 // Exif is the parsed EXIF result for the new meta/exif parser.
 type Exif struct {
-	GPS          GPSInfo
-	IFD0         IFD0Tag
-	ExifIFD      ExifIFDTags
-	IFD1         *ImageIFD
-	IFD2         *ImageIFD
+	GPS     GPSInfo
+	IFD0    IFD0Tag
+	ExifIFD ExifIFDTags
+	IFD1    *ImageIFD
+	IFD2    *ImageIFD
+	// SubIFDs holds the image-bearing SubIFDs referenced from IFD0
+	// (tag 0x014a), indexed by their position in the pointer list. Raw
+	// formats store their embedded previews here (e.g. NEF "JpgFromRaw").
+	SubIFDs      [8]*ImageIFD
 	MakerNote    makernote.Info
 	CameraSerial string
 	CameraMakeID makernote.CameraMake

--- a/meta/exif/parser.go
+++ b/meta/exif/parser.go
@@ -168,10 +168,16 @@ func (r *Reader) parseTag(t tag.Entry) {
 			return
 		}
 	case tag.IFD1:
+		if r.Exif.IFD1 == nil {
+			r.Exif.IFD1 = &ImageIFD{}
+		}
 		if !r.parseImageIFDTag(t, r.Exif.IFD1) {
 			return
 		}
 	case tag.IFD2:
+		if r.Exif.IFD2 == nil {
+			r.Exif.IFD2 = &ImageIFD{}
+		}
 		if !r.parseImageIFDTag(t, r.Exif.IFD2) {
 			return
 		}
@@ -189,7 +195,13 @@ func (r *Reader) parseTag(t tag.Entry) {
 			return
 		}
 	case tag.SubIFD0, tag.SubIFD1, tag.SubIFD2, tag.SubIFD3, tag.SubIFD4, tag.SubIFD5, tag.SubIFD6, tag.SubIFD7:
-		// SubIFD{0..7} tags are normalized through ExifIFD parsing semantics.
+		idx := int(t.IfdType - tag.SubIFD0)
+		if r.Exif.SubIFDs[idx] == nil {
+			r.Exif.SubIFDs[idx] = &ImageIFD{}
+		}
+		if !r.parseImageIFDTag(t, r.Exif.SubIFDs[idx]) {
+			return
+		}
 	default:
 		return
 	}

--- a/meta/exif/values.go
+++ b/meta/exif/values.go
@@ -505,6 +505,7 @@ func (r *Reader) parseUint32List(t tag.Entry, dst []uint32) int {
 		switch t.Type {
 		case tag.TypeLong, tag.TypeIfd:
 			dst[0] = t.EmbeddedLong()
+			return 1
 		case tag.TypeShort:
 			var shorts [2]uint16
 			m := min(t.EmbeddedShorts(shorts[:]), n)

--- a/meta/exif/values_embedded_test.go
+++ b/meta/exif/values_embedded_test.go
@@ -1,0 +1,28 @@
+package exif
+
+import (
+	"testing"
+
+	"github.com/evanoberholster/imagemeta/meta/exif/tag"
+	metalog "github.com/evanoberholster/imagemeta/meta/logging"
+	"github.com/evanoberholster/imagemeta/meta/utils"
+)
+
+func TestParseFirstUint32FromEmbeddedLong(t *testing.T) {
+	t.Parallel()
+
+	r := NewReader(metalog.GetLogger())
+	defer r.Close()
+
+	// a single LONG is embedded in the entry's value field; JPEGInterchangeFormat
+	// offsets and lengths arrive exactly like this
+	entry := tag.NewEntry(tag.TagThumbnailOffset, tag.TypeLong, 1, 166912, tag.SubIFD0, 0, utils.LittleEndian)
+
+	var dst ImageIFD
+	if !r.parseImageIFDTag(entry, &dst) {
+		t.Fatal("parseImageIFDTag(TagThumbnailOffset) = false, want true")
+	}
+	if got, want := dst.ImageOffset, uint32(166912); got != want {
+		t.Fatalf("ImageIFD.ImageOffset = %d, want %d", got, want)
+	}
+}

--- a/preview_tiff.go
+++ b/preview_tiff.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"sort"
 
-	"github.com/evanoberholster/imagemeta/meta"
 	"github.com/evanoberholster/imagemeta/meta/exif"
 	"github.com/pkg/errors"
 )
@@ -26,9 +25,17 @@ type PreviewImage struct {
 	Length uint32
 }
 
+// sofScanLimit bounds how many bytes of a candidate stream are inspected
+// for the JPEG SOF marker; metadata segments (APPn, DQT, DHT) rarely exceed
+// a few KB before the SOF appears.
+const sofScanLimit = 64 * 1024
+
 // TIFFPreviews lists the embedded JPEG preview images of a TIFF-based raw
-// file (e.g. NEF, CR2, ARW, DNG), largest first. The offsets are relative
-// to the start of the file.
+// file (e.g. NEF, CR2, ARW, DNG, PEF), largest first. The offsets are
+// relative to the start of the file. Candidates are validated against the
+// actual stream: only renderable JPEGs qualify, which keeps raw sensor
+// payloads out (DNG stores those as lossless JPEG, uncompressed or
+// vendor-compressed strips).
 func TIFFPreviews(r io.ReadSeeker) ([]PreviewImage, error) {
 	if _, err := r.Seek(0, io.SeekStart); err != nil {
 		return nil, errors.Wrapf(err, "seek to file start")
@@ -39,31 +46,31 @@ func TIFFPreviews(r io.ReadSeeker) ([]PreviewImage, error) {
 	}
 
 	var previews []PreviewImage
-	// IFD0 carries the JPEGInterchangeFormat pair in dedicated fields; the
-	// pointed-to stream is a JPEG per TIFF/EP, no compression tag needed.
-	if ex.IFD0.ThumbnailOffset != 0 && ex.IFD0.ThumbnailLength != 0 {
-		previews = append(previews, PreviewImage{
-			IFD:    "IFD0",
-			Offset: ex.IFD0.ThumbnailOffset,
-			Length: ex.IFD0.ThumbnailLength,
-		})
-	}
-	addImageIFD := func(name string, ifd *exif.ImageIFD) {
-		if ifd == nil || ifd.ImageOffset == 0 || ifd.ImageLength == 0 {
+	add := func(name string, width, height, offset, length uint32) {
+		if offset == 0 || length == 0 {
 			return
 		}
-		// ImageOffset also captures strip-based (e.g. uncompressed)
-		// images; only JPEG streams qualify as extractable previews
-		if !isJPEGCompression(ifd.Compression) {
+		if !isRenderableJPEGAt(r, offset, length) {
 			return
 		}
 		previews = append(previews, PreviewImage{
 			IFD:    name,
-			Width:  ifd.ImageWidth,
-			Height: ifd.ImageHeight,
-			Offset: ifd.ImageOffset,
-			Length: ifd.ImageLength,
+			Width:  width,
+			Height: height,
+			Offset: offset,
+			Length: length,
 		})
+	}
+
+	// IFD0 can carry both the JPEGInterchangeFormat pair (thumbnails) and a
+	// strip-based image (CR2 stores its full-size JPEG that way)
+	add("IFD0", 0, 0, ex.IFD0.ThumbnailOffset, ex.IFD0.ThumbnailLength)
+	add("IFD0", ex.IFD0.ImageWidth, ex.IFD0.ImageHeight, ex.IFD0.ImageOffset, ex.IFD0.ImageLength)
+	addImageIFD := func(name string, ifd *exif.ImageIFD) {
+		if ifd == nil {
+			return
+		}
+		add(name, ifd.ImageWidth, ifd.ImageHeight, ifd.ImageOffset, ifd.ImageLength)
 	}
 	addImageIFD("IFD1", ex.IFD1)
 	addImageIFD("IFD2", ex.IFD2)
@@ -114,12 +121,57 @@ func PreviewTIFF(r io.ReadSeeker) ([]byte, error) {
 	return nil, ErrNoPreview
 }
 
-// isJPEGCompression reports whether the TIFF compression value denotes an
-// extractable JPEG stream (old-style, new-style, and their vendor aliases).
-func isJPEGCompression(c meta.Compression) bool {
-	switch c {
-	case 6, 7, 99, 34892:
-		return true
+// isRenderableJPEGAt reads the head of a candidate stream and reports
+// whether it is a JPEG that common decoders can render.
+func isRenderableJPEGAt(r io.ReadSeeker, offset, length uint32) bool {
+	if _, err := r.Seek(int64(offset), io.SeekStart); err != nil {
+		return false
+	}
+	window := min(int(length), sofScanLimit)
+	buf := make([]byte, window)
+	n, err := io.ReadFull(r, buf)
+	if err != nil && n == 0 {
+		return false
+	}
+	return isRenderableJPEG(buf[:n])
+}
+
+// isRenderableJPEG walks the JPEG segments until the SOF marker and accepts
+// only the DCT processes common decoders implement. Raw sensor payloads in
+// DNGs are lossless JPEG (SOF3) and start with the same SOI marker, so the
+// SOI alone does not qualify a stream.
+func isRenderableJPEG(buf []byte) bool {
+	if len(buf) < 4 || buf[0] != 0xff || buf[1] != 0xd8 {
+		return false
+	}
+	i := 2
+	for i+4 <= len(buf) {
+		if buf[i] != 0xff {
+			return false
+		}
+		marker := buf[i+1]
+		switch {
+		case marker == 0xff: // fill byte
+			i++
+			continue
+		case marker >= 0xd0 && marker <= 0xd7: // RST, no length field
+			i += 2
+			continue
+		}
+		switch marker {
+		case 0xc0, 0xc1, 0xc2: // baseline, extended sequential, progressive
+			return true
+		case 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf:
+			// lossless, differential and arithmetic processes
+			return false
+		case 0xd9, 0xda: // EOI or scan start without a SOF
+			return false
+		}
+		segLen := int(buf[i+2])<<8 | int(buf[i+3])
+		if segLen < 2 {
+			return false
+		}
+		i += 2 + segLen
 	}
 	return false
 }

--- a/preview_tiff.go
+++ b/preview_tiff.go
@@ -1,0 +1,125 @@
+package imagemeta
+
+import (
+	"io"
+	"sort"
+
+	"github.com/evanoberholster/imagemeta/meta"
+	"github.com/evanoberholster/imagemeta/meta/exif"
+	"github.com/pkg/errors"
+)
+
+// ErrNoPreview is returned when a file contains no embedded preview image.
+var ErrNoPreview = errors.New("error no embedded preview image found")
+
+// PreviewImage describes an embedded JPEG preview of a TIFF-based (raw)
+// file. Offset and Length locate the JPEG stream in the file.
+type PreviewImage struct {
+	// IFD names the directory the preview was found in ("IFD0", "IFD1",
+	// "SubIFD1", ...).
+	IFD string
+	// Width and Height are the dimensions declared by the directory; zero
+	// when the directory does not declare them.
+	Width  uint32
+	Height uint32
+	Offset uint32
+	Length uint32
+}
+
+// TIFFPreviews lists the embedded JPEG preview images of a TIFF-based raw
+// file (e.g. NEF, CR2, ARW, DNG), largest first. The offsets are relative
+// to the start of the file.
+func TIFFPreviews(r io.ReadSeeker) ([]PreviewImage, error) {
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return nil, errors.Wrapf(err, "seek to file start")
+	}
+	ex, err := DecodeTiff(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var previews []PreviewImage
+	// IFD0 carries the JPEGInterchangeFormat pair in dedicated fields; the
+	// pointed-to stream is a JPEG per TIFF/EP, no compression tag needed.
+	if ex.IFD0.ThumbnailOffset != 0 && ex.IFD0.ThumbnailLength != 0 {
+		previews = append(previews, PreviewImage{
+			IFD:    "IFD0",
+			Offset: ex.IFD0.ThumbnailOffset,
+			Length: ex.IFD0.ThumbnailLength,
+		})
+	}
+	addImageIFD := func(name string, ifd *exif.ImageIFD) {
+		if ifd == nil || ifd.ImageOffset == 0 || ifd.ImageLength == 0 {
+			return
+		}
+		// ImageOffset also captures strip-based (e.g. uncompressed)
+		// images; only JPEG streams qualify as extractable previews
+		if !isJPEGCompression(ifd.Compression) {
+			return
+		}
+		previews = append(previews, PreviewImage{
+			IFD:    name,
+			Width:  ifd.ImageWidth,
+			Height: ifd.ImageHeight,
+			Offset: ifd.ImageOffset,
+			Length: ifd.ImageLength,
+		})
+	}
+	addImageIFD("IFD1", ex.IFD1)
+	addImageIFD("IFD2", ex.IFD2)
+	subIFDNames := [8]string{
+		"SubIFD0", "SubIFD1", "SubIFD2", "SubIFD3",
+		"SubIFD4", "SubIFD5", "SubIFD6", "SubIFD7",
+	}
+	for i, sub := range ex.SubIFDs {
+		addImageIFD(subIFDNames[i], sub)
+	}
+
+	sort.Slice(previews, func(i, j int) bool { return previews[i].Length > previews[j].Length })
+	return previews, nil
+}
+
+// ExtractPreview reads the bytes of one preview and validates the JPEG SOI
+// marker. The returned slice is newly allocated.
+func ExtractPreview(r io.ReadSeeker, p PreviewImage) ([]byte, error) {
+	if p.Offset == 0 || p.Length == 0 {
+		return nil, ErrNoPreview
+	}
+	if _, err := r.Seek(int64(p.Offset), io.SeekStart); err != nil {
+		return nil, errors.Wrapf(err, "seek to preview offset %d", p.Offset)
+	}
+	buf := make([]byte, p.Length)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, errors.Wrapf(err, "read preview at offset %d", p.Offset)
+	}
+	if len(buf) < 3 || buf[0] != 0xff || buf[1] != 0xd8 {
+		return nil, ErrNoPreview
+	}
+	return buf, nil
+}
+
+// PreviewTIFF returns the largest embedded JPEG preview of a TIFF-based
+// (raw) file, e.g. NEF/CR2/ARW/DNG, analog to PreviewCR3.
+func PreviewTIFF(r io.ReadSeeker) ([]byte, error) {
+	previews, err := TIFFPreviews(r)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range previews {
+		buf, err := ExtractPreview(r, p)
+		if err == nil {
+			return buf, nil
+		}
+	}
+	return nil, ErrNoPreview
+}
+
+// isJPEGCompression reports whether the TIFF compression value denotes an
+// extractable JPEG stream (old-style, new-style, and their vendor aliases).
+func isJPEGCompression(c meta.Compression) bool {
+	switch c {
+	case 6, 7, 99, 34892:
+		return true
+	}
+	return false
+}

--- a/preview_tiff.go
+++ b/preview_tiff.go
@@ -30,6 +30,10 @@ type PreviewImage struct {
 // a few KB before the SOF appears.
 const sofScanLimit = 64 * 1024
 
+// maxJPEGSegments bounds the header segments walked before the SOF marker;
+// real files reach it within a handful, this bounds work on crafted streams.
+const maxJPEGSegments = 32
+
 // TIFFPreviews lists the embedded JPEG preview images of a TIFF-based raw
 // file (e.g. NEF, CR2, ARW, DNG, PEF), largest first. The offsets are
 // relative to the start of the file. Candidates are validated against the
@@ -92,6 +96,16 @@ func ExtractPreview(r io.ReadSeeker, p PreviewImage) ([]byte, error) {
 	if p.Offset == 0 || p.Length == 0 {
 		return nil, ErrNoPreview
 	}
+	// Length is attacker-controlled; reject a preview whose extent lies
+	// outside the file before allocating, so a bogus huge length cannot force
+	// a large allocation
+	size, err := r.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, errors.Wrapf(err, "determine file size")
+	}
+	if int64(p.Offset)+int64(p.Length) > size {
+		return nil, ErrNoPreview
+	}
 	if _, err := r.Seek(int64(p.Offset), io.SeekStart); err != nil {
 		return nil, errors.Wrapf(err, "seek to preview offset %d", p.Offset)
 	}
@@ -145,7 +159,7 @@ func isRenderableJPEG(buf []byte) bool {
 		return false
 	}
 	i := 2
-	for i+4 <= len(buf) {
+	for segments := 0; i+4 <= len(buf) && segments < maxJPEGSegments; segments++ {
 		if buf[i] != 0xff {
 			return false
 		}

--- a/preview_tiff.go
+++ b/preview_tiff.go
@@ -34,13 +34,43 @@ const sofScanLimit = 64 * 1024
 // real files reach it within a handful, this bounds work on crafted streams.
 const maxJPEGSegments = 32
 
+// PreviewOption configures preview extraction.
+type PreviewOption func(*previewConfig)
+
+type previewConfig struct {
+	// maxLength caps the byte length of a preview that will be surfaced or
+	// extracted; 0 means no limit beyond the file size. The declared length
+	// is attacker-controlled, so a consumer should set the size it tolerates.
+	maxLength int64
+}
+
+func newPreviewConfig(opts []PreviewOption) previewConfig {
+	var c previewConfig
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// WithMaxPreviewLength bounds the byte length of a preview that TIFFPreviews
+// surfaces and ExtractPreview reads. A value <= 0 disables the limit (the
+// preview is still bounded by the file size).
+func WithMaxPreviewLength(n int64) PreviewOption {
+	return func(c *previewConfig) { c.maxLength = n }
+}
+
+func (c previewConfig) exceedsMax(length uint32) bool {
+	return c.maxLength > 0 && int64(length) > c.maxLength
+}
+
 // TIFFPreviews lists the embedded JPEG preview images of a TIFF-based raw
 // file (e.g. NEF, CR2, ARW, DNG, PEF), largest first. The offsets are
 // relative to the start of the file. Candidates are validated against the
 // actual stream: only renderable JPEGs qualify, which keeps raw sensor
 // payloads out (DNG stores those as lossless JPEG, uncompressed or
 // vendor-compressed strips).
-func TIFFPreviews(r io.ReadSeeker) ([]PreviewImage, error) {
+func TIFFPreviews(r io.ReadSeeker, opts ...PreviewOption) ([]PreviewImage, error) {
+	cfg := newPreviewConfig(opts)
 	if _, err := r.Seek(0, io.SeekStart); err != nil {
 		return nil, errors.Wrapf(err, "seek to file start")
 	}
@@ -51,7 +81,7 @@ func TIFFPreviews(r io.ReadSeeker) ([]PreviewImage, error) {
 
 	var previews []PreviewImage
 	add := func(name string, width, height, offset, length uint32) {
-		if offset == 0 || length == 0 {
+		if offset == 0 || length == 0 || cfg.exceedsMax(length) {
 			return
 		}
 		if !isRenderableJPEGAt(r, offset, length) {
@@ -92,13 +122,13 @@ func TIFFPreviews(r io.ReadSeeker) ([]PreviewImage, error) {
 
 // ExtractPreview reads the bytes of one preview and validates the JPEG SOI
 // marker. The returned slice is newly allocated.
-func ExtractPreview(r io.ReadSeeker, p PreviewImage) ([]byte, error) {
-	if p.Offset == 0 || p.Length == 0 {
+func ExtractPreview(r io.ReadSeeker, p PreviewImage, opts ...PreviewOption) ([]byte, error) {
+	cfg := newPreviewConfig(opts)
+	if p.Offset == 0 || p.Length == 0 || cfg.exceedsMax(p.Length) {
 		return nil, ErrNoPreview
 	}
-	// Length is attacker-controlled; reject a preview whose extent lies
-	// outside the file before allocating, so a bogus huge length cannot force
-	// a large allocation
+	// reject a preview whose extent lies outside the file before allocating,
+	// so an attacker-controlled length cannot force a large allocation
 	size, err := r.Seek(0, io.SeekEnd)
 	if err != nil {
 		return nil, errors.Wrapf(err, "determine file size")
@@ -121,13 +151,13 @@ func ExtractPreview(r io.ReadSeeker, p PreviewImage) ([]byte, error) {
 
 // PreviewTIFF returns the largest embedded JPEG preview of a TIFF-based
 // (raw) file, e.g. NEF/CR2/ARW/DNG, analog to PreviewCR3.
-func PreviewTIFF(r io.ReadSeeker) ([]byte, error) {
-	previews, err := TIFFPreviews(r)
+func PreviewTIFF(r io.ReadSeeker, opts ...PreviewOption) ([]byte, error) {
+	previews, err := TIFFPreviews(r, opts...)
 	if err != nil {
 		return nil, err
 	}
 	for _, p := range previews {
-		buf, err := ExtractPreview(r, p)
+		buf, err := ExtractPreview(r, p, opts...)
 		if err == nil {
 			return buf, nil
 		}

--- a/preview_tiff_test.go
+++ b/preview_tiff_test.go
@@ -1,0 +1,137 @@
+package imagemeta
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/jpeg"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func encodeTestJPEG(t *testing.T, width, height int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, image.NewRGBA(image.Rect(0, 0, width, height)), nil); err != nil {
+		t.Fatalf("encode test jpeg: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// buildTIFFWithPreviews assembles a minimal little-endian TIFF mimicking the
+// NEF layout: IFD0 carries a thumbnail JPEG pair plus a SubIFDs pointer, the
+// SubIFD carries the full-size preview JPEG ("JpgFromRaw").
+func buildTIFFWithPreviews(thumb, preview []byte) []byte {
+	le := binary.LittleEndian
+	const (
+		tagCompression = 0x0103
+		tagSubIFDs     = 0x014a
+		tagJPEGOffset  = 0x0201
+		tagJPEGLength  = 0x0202
+		typeShort      = 3
+		typeLong       = 4
+	)
+
+	entry := func(id, typ uint16, value uint32) []byte {
+		e := le.AppendUint16(nil, id)
+		e = le.AppendUint16(e, typ)
+		e = le.AppendUint32(e, 1)
+		return le.AppendUint32(e, value)
+	}
+
+	buf := []byte{'I', 'I', 42, 0, 8, 0, 0, 0}
+	// layout: header(8) ifd0(2+3*12+4) subifd(2+3*12+4) thumb preview
+	ifd0Start := uint32(len(buf))
+	subifdStart := ifd0Start + 2 + 3*12 + 4
+	thumbStart := subifdStart + 2 + 3*12 + 4
+	previewStart := thumbStart + uint32(len(thumb))
+
+	ifd0 := le.AppendUint16(nil, 3)
+	ifd0 = append(ifd0, entry(tagSubIFDs, typeLong, subifdStart)...)
+	ifd0 = append(ifd0, entry(tagJPEGOffset, typeLong, thumbStart)...)
+	ifd0 = append(ifd0, entry(tagJPEGLength, typeLong, uint32(len(thumb)))...)
+	ifd0 = le.AppendUint32(ifd0, 0)
+
+	subifd := le.AppendUint16(nil, 3)
+	subifd = append(subifd, entry(tagCompression, typeShort, 6)...)
+	subifd = append(subifd, entry(tagJPEGOffset, typeLong, previewStart)...)
+	subifd = append(subifd, entry(tagJPEGLength, typeLong, uint32(len(preview)))...)
+	subifd = le.AppendUint32(subifd, 0)
+
+	buf = append(buf, ifd0...)
+	buf = append(buf, subifd...)
+	buf = append(buf, thumb...)
+	return append(buf, preview...)
+}
+
+func TestTIFFPreviews(t *testing.T) {
+	t.Parallel()
+
+	thumb := encodeTestJPEG(t, 16, 8)
+	preview := encodeTestJPEG(t, 64, 32)
+	r := bytes.NewReader(buildTIFFWithPreviews(thumb, preview))
+
+	previews, err := TIFFPreviews(r)
+	if err != nil {
+		t.Fatalf("TIFFPreviews: %v", err)
+	}
+	if len(previews) != 2 {
+		t.Fatalf("len(previews) = %d, want 2", len(previews))
+	}
+	if previews[0].IFD != "SubIFD0" || previews[0].Length != uint32(len(preview)) {
+		t.Fatalf("previews[0] = %+v, want the SubIFD0 preview of %d bytes", previews[0], len(preview))
+	}
+	if previews[1].IFD != "IFD0" || previews[1].Length != uint32(len(thumb)) {
+		t.Fatalf("previews[1] = %+v, want the IFD0 thumbnail of %d bytes", previews[1], len(thumb))
+	}
+
+	got, err := ExtractPreview(r, previews[0])
+	if err != nil {
+		t.Fatalf("ExtractPreview: %v", err)
+	}
+	if !bytes.Equal(got, preview) {
+		t.Fatal("ExtractPreview returned different bytes than the embedded preview")
+	}
+}
+
+func TestPreviewTIFF(t *testing.T) {
+	t.Parallel()
+
+	thumb := encodeTestJPEG(t, 16, 8)
+	preview := encodeTestJPEG(t, 64, 32)
+	r := bytes.NewReader(buildTIFFWithPreviews(thumb, preview))
+
+	got, err := PreviewTIFF(r)
+	if err != nil {
+		t.Fatalf("PreviewTIFF: %v", err)
+	}
+	if !bytes.Equal(got, preview) {
+		t.Fatal("PreviewTIFF did not return the largest embedded preview")
+	}
+}
+
+func TestPreviewTIFFNoPreview(t *testing.T) {
+	t.Parallel()
+
+	// both "previews" point at non-JPEG bytes: they are listed by their
+	// tags but fail SOI validation, so no preview survives
+	junk := bytes.Repeat([]byte{0x42}, 64)
+	r := bytes.NewReader(buildTIFFWithPreviews(junk, junk))
+
+	if _, err := PreviewTIFF(r); !errors.Is(err, ErrNoPreview) {
+		t.Fatalf("PreviewTIFF error = %v, want ErrNoPreview", err)
+	}
+}
+
+func TestExtractPreviewValidatesSOI(t *testing.T) {
+	t.Parallel()
+
+	thumb := encodeTestJPEG(t, 16, 8)
+	preview := encodeTestJPEG(t, 64, 32)
+	r := bytes.NewReader(buildTIFFWithPreviews(thumb, preview))
+
+	if _, err := ExtractPreview(r, PreviewImage{IFD: "IFD0", Offset: 4, Length: 16}); !errors.Is(err, ErrNoPreview) {
+		t.Fatalf("ExtractPreview error = %v, want ErrNoPreview", err)
+	}
+}

--- a/preview_tiff_test.go
+++ b/preview_tiff_test.go
@@ -184,3 +184,31 @@ func TestIsRenderableJPEGSegmentCap(t *testing.T) {
 		t.Fatal("isRenderableJPEG walked past the segment cap")
 	}
 }
+
+func TestExtractPreviewMaxLengthOption(t *testing.T) {
+	t.Parallel()
+
+	thumb := encodeTestJPEG(t, 16, 8)
+	preview := encodeTestJPEG(t, 64, 32)
+	data := buildTIFFWithPreviews(thumb, preview)
+
+	// the preview is larger than the configured limit
+	small := PreviewOption(WithMaxPreviewLength(int64(len(preview)) - 1))
+	previews, err := TIFFPreviews(bytes.NewReader(data), small)
+	if err != nil {
+		t.Fatalf("TIFFPreviews: %v", err)
+	}
+	for _, p := range previews {
+		if p.IFD == "SubIFD0" {
+			t.Fatalf("TIFFPreviews surfaced a preview exceeding the max length: %+v", p)
+		}
+	}
+	full := PreviewImage{IFD: "SubIFD0", Offset: 8, Length: uint32(len(preview))}
+	if _, err := ExtractPreview(bytes.NewReader(data), full, small); !errors.Is(err, ErrNoPreview) {
+		t.Fatalf("ExtractPreview error = %v, want ErrNoPreview", err)
+	}
+	// with no limit (default) it extracts fine
+	if _, err := PreviewTIFF(bytes.NewReader(data)); err != nil {
+		t.Fatalf("PreviewTIFF with default (unlimited): %v", err)
+	}
+}

--- a/preview_tiff_test.go
+++ b/preview_tiff_test.go
@@ -193,7 +193,7 @@ func TestExtractPreviewMaxLengthOption(t *testing.T) {
 	data := buildTIFFWithPreviews(thumb, preview)
 
 	// the preview is larger than the configured limit
-	small := PreviewOption(WithMaxPreviewLength(int64(len(preview)) - 1))
+	small := WithMaxPreviewLength(int64(len(preview)) - 1)
 	previews, err := TIFFPreviews(bytes.NewReader(data), small)
 	if err != nil {
 		t.Fatalf("TIFFPreviews: %v", err)

--- a/preview_tiff_test.go
+++ b/preview_tiff_test.go
@@ -155,3 +155,32 @@ func TestIsRenderableJPEG(t *testing.T) {
 		t.Fatal("isRenderableJPEG(garbage) = true, want false")
 	}
 }
+
+func TestExtractPreviewRejectsOutOfBoundsLength(t *testing.T) {
+	t.Parallel()
+
+	thumb := encodeTestJPEG(t, 16, 8)
+	preview := encodeTestJPEG(t, 64, 32)
+	data := buildTIFFWithPreviews(thumb, preview)
+	r := bytes.NewReader(data)
+
+	// a preview whose declared length runs past the file must not allocate it
+	p := PreviewImage{IFD: "SubIFD0", Offset: 8, Length: 0xffffffff}
+	if _, err := ExtractPreview(r, p); !errors.Is(err, ErrNoPreview) {
+		t.Fatalf("ExtractPreview error = %v, want ErrNoPreview", err)
+	}
+}
+
+func TestIsRenderableJPEGSegmentCap(t *testing.T) {
+	t.Parallel()
+
+	// SOI followed by more than maxJPEGSegments tiny APP1 segments hides the SOF
+	buf := []byte{0xff, 0xd8}
+	for n := 0; n < maxJPEGSegments+5; n++ {
+		buf = append(buf, 0xff, 0xe1, 0x00, 0x04, 0x00, 0x00)
+	}
+	buf = append(buf, 0xff, 0xc0, 0x00, 0x0b, 0x08, 0, 16, 0, 16, 0x01, 0x01, 0x11, 0x00)
+	if isRenderableJPEG(buf) {
+		t.Fatal("isRenderableJPEG walked past the segment cap")
+	}
+}

--- a/preview_tiff_test.go
+++ b/preview_tiff_test.go
@@ -135,3 +135,23 @@ func TestExtractPreviewValidatesSOI(t *testing.T) {
 		t.Fatalf("ExtractPreview error = %v, want ErrNoPreview", err)
 	}
 }
+
+func TestIsRenderableJPEG(t *testing.T) {
+	t.Parallel()
+
+	baseline := encodeTestJPEG(t, 8, 8)
+	if !isRenderableJPEG(baseline) {
+		t.Fatal("isRenderableJPEG(baseline jpeg) = false, want true")
+	}
+
+	// lossless JPEG (SOF3) is what DNG raw sensor payloads use; it starts
+	// with a regular SOI but common decoders cannot render it
+	lossless := []byte{0xff, 0xd8, 0xff, 0xc3, 0x00, 0x0b, 8, 0, 16, 0, 16, 1, 0, 0x11, 0}
+	if isRenderableJPEG(lossless) {
+		t.Fatal("isRenderableJPEG(lossless jpeg) = true, want false")
+	}
+
+	if isRenderableJPEG([]byte{0x42, 0x42, 0x42, 0x42}) {
+		t.Fatal("isRenderableJPEG(garbage) = true, want false")
+	}
+}


### PR DESCRIPTION
Implements #69.

Two commits:

1. **fix: parseUint32List drops embedded LONG values.** The embedded TypeLong/TypeIfd branch assigned `dst[0]` but fell through to `return 0`, so `parseFirstUint32` discarded the value. Every single-LONG tag read through it was affected, e.g. `JPEGInterchangeFormat` offsets and lengths (IFD0 `ThumbnailOffset`/`ThumbnailLength` were always 0). Regression test included.

2. **feat: SubIFD image info and embedded TIFF preview extraction.**
   - `parseTag` previously dropped SubIFD0..7 entries (no-op case); they now route through the existing `parseImageIFDTag` into new `Exif.SubIFDs [8]*ImageIFD` models. IFD1/IFD2 are lazily allocated on first tag, so their parsed tags are retained (previously they were written into a discarded throwaway struct when nil).
   - New public API in `preview_tiff.go`:
     - `TIFFPreviews(r io.ReadSeeker) ([]PreviewImage, error)` lists the embedded JPEG previews (largest first) with IFD name, dimensions, offset and length. Strip-based non-JPEG images are filtered by their Compression value.
     - `ExtractPreview(r io.ReadSeeker, p PreviewImage) ([]byte, error)` reads one preview and validates the JPEG SOI marker.
     - `PreviewTIFF(r io.ReadSeeker) ([]byte, error)` returns the largest preview, analog to `PreviewCR3`.

Tests use a synthetic in-code TIFF mimicking the NEF layout (IFD0 thumbnail pair + SubIFD "JpgFromRaw"), no binary fixtures. Verified against real Nikon D3000 NEFs: `TIFFPreviews` finds the full-size SubIFD0 preview (0.5-1.2 MB JPEGs), the raw sensor SubIFD (Compression 34713) is correctly excluded, `PreviewTIFF` returns the same bytes an exiftool `-JpgFromRaw` extraction yields.

`go test ./...` passes except `TestParseSonyMakerNoteSamples` (needs download_samples) and `TestMakerNoteAccessorsLazyAllocation`, both of which fail identically on current master. `golangci-lint` reports nothing for the touched files.
