### PR TITLE
meta/exif/makernote/apple: prevent stack overflow on cyclic RunTime plist

### DIFF
--- a/meta/exif/makernote/apple/apple.go
+++ b/meta/exif/makernote/apple/apple.go
@@ -180,6 +180,7 @@ func ParseRunTime(raw []byte) (AppleRunTime, bool) {
 	}
 
 	cache := make(map[int]any, numObjects)
+	visiting := make(map[int]bool)
 	var parseObject func(int) (any, bool)
 	parseObject = func(idx int) (any, bool) {
 		if v, ok := cache[idx]; ok {
@@ -188,6 +189,14 @@ func ParseRunTime(raw []byte) (AppleRunTime, bool) {
 		if idx < 0 || idx >= numObjects {
 			return nil, false
 		}
+		// Reject cyclic object references (e.g. an array or dict that refers
+		// back to itself), which would otherwise recurse until the goroutine
+		// stack is exhausted.
+		if visiting[idx] {
+			return nil, false
+		}
+		visiting[idx] = true
+		defer delete(visiting, idx)
 		off := offsets[idx]
 		if off < 0 || off >= len(raw)-32 {
 			return nil, false

--- a/meta/exif/makernote/apple/apple_runtime_test.go
+++ b/meta/exif/makernote/apple/apple_runtime_test.go
@@ -1,0 +1,57 @@
+package apple
+
+import "testing"
+
+// buildPlist assembles a minimal binary-plist body (8-byte header, objects,
+// 1-byte offset table, 32-byte trailer) using 1-byte offset and object-ref
+// sizes. objects is the concatenated object data starting at offset 8;
+// offsets are the absolute byte offsets of each object.
+func buildPlist(objects []byte, offsets []byte, topObject byte) []byte {
+	raw := []byte("bplist00")
+	raw = append(raw, objects...)
+	offTableOff := len(raw)
+	raw = append(raw, offsets...)
+	trailer := make([]byte, 32)
+	trailer[6] = 1                   // offsetIntSize
+	trailer[7] = 1                   // objRefSize
+	trailer[15] = byte(len(offsets)) // numObjects
+	trailer[23] = topObject          // topObject
+	trailer[31] = byte(offTableOff)  // offsetTableOffset
+	raw = append(raw, trailer...)
+	return raw
+}
+
+// TestParseRunTimeCyclicReference ensures a binary plist whose array refers
+// back to itself is rejected rather than recursing until the goroutine stack
+// is exhausted (an unrecoverable fatal error / DoS).
+func TestParseRunTimeCyclicReference(t *testing.T) {
+	// obj0 at offset 8: array of length 1 whose single element refers to obj0.
+	objects := []byte{0xA1, 0x00}
+	offsets := []byte{0x08}
+	raw := buildPlist(objects, offsets, 0)
+
+	if _, ok := ParseRunTime(raw); ok {
+		t.Fatalf("expected ParseRunTime to reject cyclic plist")
+	}
+}
+
+// TestParseRunTimeValidDict confirms a well-formed binary-plist dictionary is
+// still parsed correctly after the cycle guard was added.
+func TestParseRunTimeValidDict(t *testing.T) {
+	// obj0 dict{obj1:obj2}, obj1 string "flags", obj2 int 42.
+	objects := []byte{
+		0xD1, 0x01, 0x02, // off 8: dict len1 key->1 val->2
+		0x55, 'f', 'l', 'a', 'g', 's', // off 11: string "flags"
+		0x10, 0x2A, // off 17: int 42
+	}
+	offsets := []byte{0x08, 0x0B, 0x11}
+	raw := buildPlist(objects, offsets, 0)
+
+	rt, ok := ParseRunTime(raw)
+	if !ok {
+		t.Fatalf("expected ParseRunTime to parse valid dict")
+	}
+	if rt.Flags != 42 {
+		t.Fatalf("Flags = %d, want 42", rt.Flags)
+	}
+}


### PR DESCRIPTION
### What

`ParseRunTime` (Apple `RunTime` maker-note) decodes its payload as a binary plist. Container objects (arrays / dicts) are parsed by a recursive closure, and the result cache for a container is only written *after* its recursion finishes. A payload whose array or dict object references itself therefore recurses forever without ever hitting the cache, exhausting the goroutine stack and aborting the whole process with a fatal `stack overflow` — which `recover` cannot intercept.

This is reachable from the documented entry point on untrusted input: `imagemeta.Decode` → EXIF maker-note parsing → the Apple `RunTime` tag → `ParseRunTime`, so a single crafted image can take down a process that only meant to read metadata.

### Repro

A ~54-byte plist body (no `bplist00`-vs-header dependency) with one array object that lists itself is enough:

```go
// obj0 @ offset 8: array len 1 whose only element is a ref to obj0
objects := []byte{0xA1, 0x00}
offsets := []byte{0x08}
raw := buildPlist(objects, offsets, 0) // header + objects + offset table + 32-byte trailer
apple.ParseRunTime(raw)                // runtime: goroutine stack exceeds 1000000000-byte limit
```

### Fix

Track the objects currently on the recursion path and reject a reference to an object that is already being parsed, so a cyclic plist is skipped like any other malformed maker-note instead of crashing.

Included tests:

- `TestParseRunTimeCyclicReference` — crashes before the change, passes after.
- `TestParseRunTimeValidDict` — a well-formed dictionary still parses correctly.

`go test ./meta/exif/makernote/apple/...` passes. The two pre-existing failures under `meta/exif` (`TestParseSonyMakerNoteSamples`, `TestMakerNoteAccessorsLazyAllocation`) need the uncommitted `download_samples` catalog and fail identically on a clean checkout; they are unrelated to this change.
