### PR TITLE
BigTIFF (DNG 1.7) support in the TIFF/EXIF decoder

### DIFF
--- a/bigtiff_test.go
+++ b/bigtiff_test.go
@@ -1,0 +1,129 @@
+package imagemeta
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/evanoberholster/imagemeta/imagetype"
+)
+
+// buildBigTIFF assembles a minimal little-endian BigTIFF (DNG 1.7) container
+// exercising every value-mapping path: an at-offset ASCII string (Make), an
+// inline ASCII string (Model), an inline 8-byte RATIONAL (XResolution) and two
+// numeric-scalar offsets, one carried as a 64-bit LONG8 (JPEGInterchangeFormat).
+func buildBigTIFF(makeStr, model string, xresNum uint32, preview []byte) []byte {
+	le := binary.LittleEndian
+	const (
+		tagMake       = 0x010F
+		tagModel      = 0x0110
+		tagXReson     = 0x011A
+		tagJPEGOffset = 0x0201
+		tagJPEGLength = 0x0202
+		typeASCII     = 2
+		typeLong      = 4
+		typeRational  = 5
+		typeLong8     = 16
+	)
+
+	// entry: id[2] type[2] count[8] value/offset[8, left-justified]
+	entry := func(id, typ uint16, count uint64, value []byte) []byte {
+		e := le.AppendUint16(nil, id)
+		e = le.AppendUint16(e, typ)
+		e = le.AppendUint64(e, count)
+		slot := make([]byte, 8)
+		copy(slot, value)
+		return append(e, slot...)
+	}
+
+	const entryCount = 5
+	// header(16) + count(8) + entries(5*20) + next(8)
+	ifd0Start := uint64(16)
+	dataStart := ifd0Start + 8 + entryCount*20 + 8
+	makeBytes := append([]byte(makeStr), 0)
+	makeOffset := dataStart
+	previewStart := dataStart + uint64(len(makeBytes))
+
+	rational := le.AppendUint32(nil, xresNum)
+	rational = le.AppendUint32(rational, 1) // denominator
+
+	ifd0 := le.AppendUint64(nil, entryCount)
+	ifd0 = append(ifd0, entry(tagMake, typeASCII, uint64(len(makeBytes)), le.AppendUint64(nil, makeOffset))...)
+	ifd0 = append(ifd0, entry(tagModel, typeASCII, uint64(len(model)+1), append([]byte(model), 0))...)
+	ifd0 = append(ifd0, entry(tagXReson, typeRational, 1, rational)...)
+	ifd0 = append(ifd0, entry(tagJPEGOffset, typeLong8, 1, le.AppendUint64(nil, previewStart))...)
+	ifd0 = append(ifd0, entry(tagJPEGLength, typeLong, 1, le.AppendUint32(nil, uint32(len(preview))))...)
+	ifd0 = le.AppendUint64(ifd0, 0) // no next IFD
+
+	buf := []byte{'I', 'I', 43, 0, 8, 0, 0, 0}
+	buf = le.AppendUint64(buf, ifd0Start)
+	buf = append(buf, ifd0...)
+	buf = append(buf, makeBytes...)
+	return append(buf, preview...)
+}
+
+func TestBigTIFFImageTypeDetection(t *testing.T) {
+	preview := encodeTestJPEG(t, 8, 8)
+	data := buildBigTIFF("Make", "Model", 300, preview)
+	it, err := imagetype.Buf(data)
+	if err != nil {
+		t.Fatalf("imagetype.Buf: %v", err)
+	}
+	if it != imagetype.ImageTiff {
+		t.Fatalf("imagetype.Buf: want ImageTiff, got %s", it)
+	}
+}
+
+func TestBigTIFFDecodeMetadata(t *testing.T) {
+	preview := encodeTestJPEG(t, 8, 8)
+	data := buildBigTIFF("TestMake", "Cam", 300, preview)
+
+	ex, err := DecodeTiff(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("DecodeTiff: %v", err)
+	}
+	// Make is read from a file offset; imagemeta canonicalizes it to lower case.
+	if !strings.EqualFold(ex.IFD0.Make, "TestMake") {
+		t.Errorf("Make: want %q (any case), got %q (at-offset ASCII)", "TestMake", ex.IFD0.Make)
+	}
+	if ex.IFD0.Model != "Cam" {
+		t.Errorf("Model: want %q, got %q (inline ASCII)", "Cam", ex.IFD0.Model)
+	}
+	// The RATIONAL is packed inline in the 8-byte BigTIFF value field: this is
+	// the path that needs the full 8 inline bytes, not just the low four.
+	if ex.IFD0.XResolution != 300 {
+		t.Errorf("XResolution: want 300, got %v (inline 8-byte RATIONAL)", ex.IFD0.XResolution)
+	}
+}
+
+func TestBigTIFFPreviewExtraction(t *testing.T) {
+	preview := encodeTestJPEG(t, 32, 16)
+	data := buildBigTIFF("Make", "Model", 72, preview)
+	r := bytes.NewReader(data)
+
+	previews, err := TIFFPreviews(r)
+	if err != nil {
+		t.Fatalf("TIFFPreviews: %v", err)
+	}
+	if len(previews) != 1 {
+		t.Fatalf("want 1 preview, got %d", len(previews))
+	}
+	got, err := ExtractPreview(r, previews[0])
+	if err != nil {
+		t.Fatalf("ExtractPreview: %v", err)
+	}
+	if !bytes.Equal(got, preview) {
+		t.Fatalf("preview bytes mismatch: want %d bytes, got %d", len(preview), len(got))
+	}
+}
+
+func TestBigTIFFRejectsBadOffsetSize(t *testing.T) {
+	preview := encodeTestJPEG(t, 8, 8)
+	data := buildBigTIFF("Make", "Model", 300, preview)
+	data[4] = 4 // offset size must be 8; a malformed header must not be parsed
+
+	if _, err := DecodeTiff(bytes.NewReader(data)); err == nil {
+		t.Fatal("DecodeTiff: expected error for malformed BigTIFF offset size")
+	}
+}

--- a/imagetype/imagetype.go
+++ b/imagetype/imagetype.go
@@ -945,6 +945,10 @@ var (
 	tiffLittleEndianSignature = []byte{0x49, 0x49, 0x2A, 0x00}
 	tiffBigEndianSignature    = []byte{0x4D, 0x4D, 0x00, 0x2A}
 
+	// BigTIFF (magic 43) signatures, allowed for DNG since spec 1.7.
+	bigTiffLittleEndianSignature = []byte{0x49, 0x49, 0x2B, 0x00}
+	bigTiffBigEndianSignature    = []byte{0x4D, 0x4D, 0x00, 0x2B}
+
 	crwByteOrderSignature = []byte{0x49, 0x49}
 	crwHeapSignature      = []byte("HEAPCCDR")
 	cr2Signature          = []byte{0x43, 0x52, 0x02, 0x00}
@@ -1049,9 +1053,15 @@ func hasAnyCompatibleBrand(buf []byte, brands ...[]byte) bool {
 	return false
 }
 
-// isTiff() Checks to see if an Image has the tiff format header.
+// isTiff() Checks to see if an Image has the tiff format header (classic or
+// BigTIFF).
 func isTiff(buf []byte) bool {
-	return IsTiffBigEndian(buf) || IsTiffLittleEndian(buf)
+	return IsTiffBigEndian(buf) || IsTiffLittleEndian(buf) || isBigTiff(buf)
+}
+
+// isBigTiff reports either BigTIFF (magic 43) byte-order signature.
+func isBigTiff(buf []byte) bool {
+	return hasPrefix(buf, bigTiffLittleEndianSignature) || hasPrefix(buf, bigTiffBigEndianSignature)
 }
 
 // IsTiffLittleEndian checks the buf for the Tiff LittleEndian Signature

--- a/imagetype/scan.go
+++ b/imagetype/scan.go
@@ -71,6 +71,11 @@ func detectShortBuffer(buf []byte) (FileType, error) {
 			return ImageTiff, nil
 		case buf[0] == 0x4D && buf[1] == 0x4D && buf[2] == 0x00 && buf[3] == 0x2A:
 			return ImageTiff, nil
+		// BigTIFF (magic 43), allowed for DNG since spec 1.7.
+		case buf[0] == 0x49 && buf[1] == 0x49 && buf[2] == 0x2B && buf[3] == 0x00:
+			return ImageTiff, nil
+		case buf[0] == 0x4D && buf[1] == 0x4D && buf[2] == 0x00 && buf[3] == 0x2B:
+			return ImageTiff, nil
 		}
 	}
 	if len(buf) >= 8 {

--- a/meta/exif/canon.go
+++ b/meta/exif/canon.go
@@ -339,7 +339,7 @@ func (r *Reader) parseCanonRawUint16List(t tag.Entry, dst []uint16, wordCount in
 			return t.EmbeddedShorts(dst[:wordCount])
 		}
 		// UNDEFINED embedded payload is up to 4 bytes.
-		t.EmbeddedValue(r.state.buf[:4])
+		t.EmbeddedValue(r.state.buf[:8])
 		n := min(wordCount, 2)
 		for i := range n {
 			start := i * 2

--- a/meta/exif/gpsinfo.go
+++ b/meta/exif/gpsinfo.go
@@ -508,7 +508,7 @@ func (r *Reader) parseGPSRef(t tag.Entry) tag.GPSRef {
 
 func (r *Reader) firstTagByte(t tag.Entry) (byte, bool) {
 	if t.IsEmbedded() {
-		t.EmbeddedValue(r.state.buf[:4])
+		t.EmbeddedValue(r.state.buf[:8])
 		return r.state.buf[0], true
 	}
 	buf, err := r.readTagBytes(t, 1)

--- a/meta/exif/parser.go
+++ b/meta/exif/parser.go
@@ -67,8 +67,13 @@ func (r *Reader) warnTagQueueFull(t tag.Entry) {
 
 // parseSubIFDs parses the requested value from EXIF metadata.
 func (r *Reader) parseSubIFDs(t tag.Entry) {
+	// SubIFD pointers are LONG/IFD (classic) or, in BigTIFF, LONG8/IFD8 with
+	// 8-byte elements. Single BigTIFF pointers are already narrowed to LONG/IFD.
+	elemSize := 4
 	switch t.Type {
 	case tag.TypeLong, tag.TypeIfd:
+	case tag.TypeLong8, tag.TypeIfd8:
+		elemSize = 8
 	default:
 		return
 	}
@@ -93,45 +98,50 @@ func (r *Reader) parseSubIFDs(t tag.Entry) {
 		return
 	}
 
-	if t.UnitCount == 1 {
-		var offset uint32
-		switch {
-		case t.IsType(tag.TypeIfd):
-			offset = t.ValueOffset
-		case t.IsEmbedded():
-			t.EmbeddedValue(r.state.buf[:4])
-			offset = t.ByteOrder.Uint32(r.state.buf[:4])
-		default:
-			buf, err := r.readTagBytes(t, 4)
-			if err != nil || len(buf) < 4 {
-				return
-			}
-			offset = t.ByteOrder.Uint32(buf[:4])
-		}
-		if offset != 0 {
-			r.appendSubIFDOffset(offset)
-			r.addTag(tag.NewEntry(t.ID, tag.TypeIfd, 1, offset, tag.SubIFD0, 0, t.ByteOrder))
+	// A single narrowed IFD pointer carries the offset directly.
+	if t.UnitCount == 1 && t.IsType(tag.TypeIfd) {
+		if t.ValueOffset != 0 {
+			r.appendSubIFDOffset(t.ValueOffset)
+			r.addTag(tag.NewEntry(t.ID, tag.TypeIfd, 1, t.ValueOffset, tag.SubIFD0, 0, t.ByteOrder))
 		}
 		return
 	}
 
-	maxBytes, ok := meta.SafecastIntToUint32(maxEntries * 4)
-	if !ok {
-		return
+	// Gather the raw offset bytes: from the inline value or from the file offset.
+	var buf []byte
+	if t.IsEmbedded() {
+		t.EmbeddedValue(r.state.buf[:8])
+		buf = r.state.buf[:8]
+	} else {
+		maxBytes, ok := meta.SafecastIntToUint32(maxEntries * elemSize)
+		if !ok {
+			return
+		}
+		b, err := r.readTagBytes(t, maxBytes)
+		if err != nil {
+			return
+		}
+		buf = b
 	}
-	buf, err := r.readTagBytes(t, maxBytes)
-	if err != nil {
-		return
-	}
-	limit := min(maxEntries, len(buf)/4)
-	for i := range limit {
+
+	limit := min(maxEntries, len(buf)/elemSize)
+	for i := 0; i < limit; i++ {
 		if r.state.len >= tagQueueMax {
 			if r.WarnEnabled() {
 				r.warnTagContext(t, "subifd queue capacity reached; stopping parse", true)
 			}
 			break
 		}
-		offset := t.ByteOrder.Uint32(buf[i*4 : i*4+4])
+		var offset uint32
+		if elemSize == 8 {
+			v := t.ByteOrder.Uint64(buf[i*8 : i*8+8])
+			if v > maxTiffOffset {
+				continue
+			}
+			offset = uint32(v)
+		} else {
+			offset = t.ByteOrder.Uint32(buf[i*4 : i*4+4])
+		}
 		if offset == 0 {
 			continue
 		}
@@ -361,7 +371,7 @@ func (r *Reader) parseMakeTag(t tag.Entry) (makeID makernote.CameraMake, makeNam
 	var raw []byte
 	if t.IsEmbedded() {
 		size := t.Size()
-		t.EmbeddedValue(r.state.buf[:4])
+		t.EmbeddedValue(r.state.buf[:8])
 		raw = trimTrailingNULBytes(r.state.buf[:size])
 	} else {
 		buf, err := r.readTagBytes(t, uint32(len(r.state.buf)))
@@ -852,7 +862,7 @@ func (r *Reader) parseSubSecTimeParts(t tag.Entry) (uint16, string) {
 	}
 	var raw []byte
 	if t.IsEmbedded() {
-		t.EmbeddedValue(r.state.buf[:4])
+		t.EmbeddedValue(r.state.buf[:8])
 		raw = trimASCIIWhitespace(trimNULBuffer(r.state.buf[:4]))
 		n, ok := meta.SafecastUintToUint16(parseStrUint(raw))
 		if !ok {

--- a/meta/exif/reader.go
+++ b/meta/exif/reader.go
@@ -58,6 +58,7 @@ type Reader struct {
 	exifLength       uint32
 	firstIFDOffset   uint32
 	tiffHeaderOffset uint32
+	bigTiff          bool
 }
 
 // NewReader creates an EXIF reader. Call Close when done.
@@ -285,6 +286,7 @@ func (r *Reader) initDecode(reader io.Reader, header meta.ExifHeader, resetExif 
 	r.Exif.ImageType = header.ImageType
 	r.firstIFDOffset = header.FirstIfdOffset
 	r.tiffHeaderOffset = header.TiffHeaderOffset
+	r.bigTiff = header.BigTIFF
 	// ExifLength == 0 means unknown length (for full TIFF/RAW streams).
 	// Keep parsing unbounded by length in that case to avoid false short-read
 	// failures on large maker-note offsets.
@@ -409,7 +411,7 @@ func (r *Reader) readDirectory(directory tag.Directory, drainQueue bool) error {
 		return nil
 	}
 	infoEnabled := r.InfoEnabled()
-	tagCount, err := r.readUint16(directory)
+	tagCount, err := r.readDirectoryTagCount(directory)
 	if err != nil {
 		if r.WarnEnabled() {
 			r.directoryLogContext(r.Warn(3), directory).
@@ -428,7 +430,12 @@ func (r *Reader) readDirectory(directory tag.Directory, drainQueue bool) error {
 		return nil
 	}
 
-	if err = r.parseDirectoryTagHeadersBulkTrusted(directory, tagCount); err != nil {
+	if r.bigTiff {
+		err = r.parseDirectoryTagHeadersBigTiff(directory, tagCount)
+	} else {
+		err = r.parseDirectoryTagHeadersBulkTrusted(directory, tagCount)
+	}
+	if err != nil {
 		if r.WarnEnabled() {
 			r.directoryLogContext(r.Warn(3), directory).
 				Err(err).
@@ -438,7 +445,7 @@ func (r *Reader) readDirectory(directory tag.Directory, drainQueue bool) error {
 		return err
 	}
 
-	nextIFDOffset, err := r.readUint32(directory)
+	nextIFDOffset, err := r.readNextIFDOffset(directory)
 	if err != nil {
 		if r.WarnEnabled() {
 			r.directoryLogContext(r.Warn(3), directory).
@@ -630,4 +637,185 @@ func (r *Reader) parseDirectoryTagHeadersBulkTrusted(directory tag.Directory, ta
 		r.addTag(t)
 	}
 	return nil
+}
+
+// readDirectoryTagCount reads an IFD entry count: 2 bytes for classic TIFF, 8
+// bytes for BigTIFF. Counts above maxTagCount are clamped to a rejecting value
+// so the caller's limit check drops the directory.
+func (r *Reader) readDirectoryTagCount(directory tag.Directory) (uint16, error) {
+	if !r.bigTiff {
+		return r.readUint16(directory)
+	}
+	count, err := r.readUint64(directory)
+	if err != nil {
+		return 0, err
+	}
+	if count > uint64(maxTagCount) {
+		return maxTagCount + 1, nil
+	}
+	return uint16(count), nil
+}
+
+// readNextIFDOffset reads the pointer to the next IFD: 4 bytes for classic TIFF,
+// 8 bytes for BigTIFF. A BigTIFF offset beyond 4 GiB ends the chain.
+func (r *Reader) readNextIFDOffset(directory tag.Directory) (uint32, error) {
+	if !r.bigTiff {
+		return r.readUint32(directory)
+	}
+	off, err := r.readUint64(directory)
+	if err != nil {
+		return 0, err
+	}
+	if off > maxTiffOffset {
+		return 0, nil
+	}
+	return uint32(off), nil
+}
+
+// parseDirectoryTagHeadersBigTiff decodes BigTIFF IFD entries (20 bytes each:
+// id[2], type[2], count[8], value/offset[8]), mirroring the classic per-entry
+// decode with 64-bit counts and an 8-byte inline value field.
+//
+// The 32-bit value model is kept: numeric scalars (offsets, lengths, dimensions
+// and IFD pointers, LONG8 included) are read at their true width and narrowed to
+// uint32, rejected past 4 GiB; other values up to 8 bytes are carried inline and
+// read back verbatim by the value parsers; larger values are read from their
+// 32-bit file offset as in classic TIFF.
+func (r *Reader) parseDirectoryTagHeadersBigTiff(directory tag.Directory, tagCount uint16) error {
+	byteOrder := directory.ByteOrder
+	directoryType := directory.Type
+	directoryIndex := directory.Index
+	baseOffset := directory.BaseOffset
+	warnEnabled := r.WarnEnabled()
+
+	for i := 0; i < int(tagCount); i++ {
+		h, err := r.fastRead(20)
+		if err != nil {
+			return err
+		}
+		if len(h) < 20 {
+			return io.ErrUnexpectedEOF
+		}
+
+		tagID := tag.ID(byteOrder.Uint16(h[:2]))
+		tagTypeValue, ok := meta.SafecastUint16ToUint8(byteOrder.Uint16(h[2:4]))
+		if !ok {
+			tagTypeValue = 0
+		}
+		wireType := tag.Type(tagTypeValue)
+		unitCount64 := byteOrder.Uint64(h[4:12])
+		slot := h[12:20]
+
+		if unitCount64 == 0 || unitCount64 > maxTiffOffset {
+			continue
+		}
+		unitCount := uint32(unitCount64)
+
+		normType := tag.NormalizeType(directoryType, tagID, wireType)
+		if !normType.IsValid() {
+			if warnEnabled {
+				r.rawTagHeaderLogContext(r.Warn(3), directory, i, tagID, wireType, unitCount, byteOrder.Uint32(slot)).
+					Err(tag.ErrTagTypeNotValid).
+					Msg("invalid exif tag header")
+			}
+			continue
+		}
+		wireSize := uint64(wireType.Size()) * unitCount64
+
+		t, ok := bigTiffEntry(tagID, wireType, normType, unitCount, wireSize, slot, directoryType, directoryIndex, baseOffset, byteOrder)
+		if !ok {
+			continue
+		}
+		if t.IsEmbedded() {
+			r.parseTag(t)
+			continue
+		}
+		r.addTag(t)
+	}
+	return nil
+}
+
+// bigTiffEntry builds a tag.Entry from a BigTIFF entry's fields, mapping the
+// 8-byte value/offset field onto the 32-bit value model. It returns false when
+// the value cannot be represented (offset or count beyond 4 GiB).
+func bigTiffEntry(tagID tag.ID, wireType, normType tag.Type, unitCount uint32, wireSize uint64, slot []byte, dirType tag.IfdType, dirIndex int8, baseOffset uint32, bo utils.ByteOrder) (tag.Entry, bool) {
+	// Numeric scalar: an offset, length, dimension or IFD pointer. Read at its
+	// true width (LONG8 included) and narrow to uint32.
+	if unitCount == 1 && isNumericScalarType(wireType) {
+		v, ok := readNumericScalar(bo, wireType, slot)
+		if !ok || v > maxTiffOffset {
+			return tag.Entry{}, false
+		}
+		outType := narrowNumericType(wireType)
+		if normType == tag.TypeIfd {
+			outType = tag.TypeIfd
+		}
+		offset := uint32(v)
+		if !isEmbeddedScalarType(outType) {
+			// pointer / deferred value read from a file offset
+			offset += baseOffset
+		}
+		return tag.NewEntry(tagID, outType, 1, offset, dirType, dirIndex, bo), true
+	}
+	// Value packed inline in the 8-byte field: carry it verbatim.
+	if wireSize <= 8 {
+		lo := bo.Uint32(slot[0:4])
+		hi := bo.Uint32(slot[4:8])
+		return tag.NewInlineEntry(tagID, normType, unitCount, lo, hi, dirType, dirIndex, bo), true
+	}
+	// Value stored at a file offset: the slot holds an 8-byte offset.
+	off := bo.Uint64(slot[0:8])
+	if off > maxTiffOffset {
+		return tag.Entry{}, false
+	}
+	return tag.NewEntry(tagID, normType, unitCount, uint32(off)+baseOffset, dirType, dirIndex, bo), true
+}
+
+// isNumericScalarType reports whether a wire type is a single integer offset,
+// count or pointer that fits the 32-bit value model once narrowed.
+func isNumericScalarType(t tag.Type) bool {
+	switch t {
+	case tag.TypeShort, tag.TypeSignedShort, tag.TypeLong, tag.TypeSignedLong,
+		tag.TypeIfd, tag.TypeLong8, tag.TypeSignedLong8, tag.TypeIfd8:
+		return true
+	}
+	return false
+}
+
+// readNumericScalar reads a single integer value from the inline field at its
+// declared width, left-justified per the TIFF value layout.
+func readNumericScalar(bo utils.ByteOrder, t tag.Type, slot []byte) (uint64, bool) {
+	switch t {
+	case tag.TypeShort, tag.TypeSignedShort:
+		return uint64(bo.Uint16(slot[0:2])), true
+	case tag.TypeLong, tag.TypeSignedLong, tag.TypeIfd:
+		return uint64(bo.Uint32(slot[0:4])), true
+	case tag.TypeLong8, tag.TypeSignedLong8, tag.TypeIfd8:
+		return bo.Uint64(slot[0:8]), true
+	}
+	return 0, false
+}
+
+// narrowNumericType maps a BigTIFF 64-bit integer type to its 32-bit equivalent
+// so the classic value parsers handle the narrowed value.
+func narrowNumericType(t tag.Type) tag.Type {
+	switch t {
+	case tag.TypeLong8:
+		return tag.TypeLong
+	case tag.TypeSignedLong8:
+		return tag.TypeSignedLong
+	case tag.TypeIfd8:
+		return tag.TypeIfd
+	}
+	return t
+}
+
+// isEmbeddedScalarType reports whether a narrowed numeric scalar is read from
+// its inline value (rather than a file offset), matching Entry.IsEmbedded.
+func isEmbeddedScalarType(t tag.Type) bool {
+	switch t {
+	case tag.TypeShort, tag.TypeSignedShort, tag.TypeLong, tag.TypeSignedLong:
+		return true
+	}
+	return false
 }

--- a/meta/exif/tag/entry.go
+++ b/meta/exif/tag/entry.go
@@ -10,12 +10,18 @@ import (
 // Layout is intentionally compact and friendly for fixed-size parser queues.
 type Entry struct {
 	ValueOffset uint32
-	UnitCount   uint32
-	ID          ID
-	Type        Type
-	IfdType     IfdType
-	IfdIndex    int8
-	ByteOrder   utils.ByteOrder
+	// valueHigh carries the upper 4 bytes of a 5-8 byte value packed inline in a
+	// BigTIFF entry's 8-byte value field. Unused (0) for classic TIFF.
+	valueHigh uint32
+	UnitCount uint32
+	ID        ID
+	Type      Type
+	IfdType   IfdType
+	IfdIndex  int8
+	// embedded forces the inline-value path regardless of the type-size
+	// heuristic; set for BigTIFF values carried in the 8-byte value field.
+	embedded  bool
+	ByteOrder utils.ByteOrder
 }
 
 // NewEntry returns a new tag Entry.
@@ -31,6 +37,24 @@ func NewEntry(id ID, typ Type, unitCount, valueOffset uint32, directoryType IfdT
 	}
 }
 
+// NewInlineEntry returns an entry whose value is packed inline in up to 8 bytes
+// (BigTIFF), with lo and hi holding the value's low and high 4 bytes. Such an
+// entry always reports IsEmbedded, so value parsers read the packed bytes
+// rather than treating ValueOffset as a file offset.
+func NewInlineEntry(id ID, typ Type, unitCount, lo, hi uint32, directoryType IfdType, ifdIndex int8, byteOrder utils.ByteOrder) Entry {
+	return Entry{
+		ValueOffset: lo,
+		valueHigh:   hi,
+		UnitCount:   unitCount,
+		ID:          id,
+		Type:        typ,
+		IfdType:     directoryType,
+		IfdIndex:    ifdIndex,
+		embedded:    true,
+		ByteOrder:   byteOrder,
+	}
+}
+
 func (t Entry) Name() string {
 	return NameFor(t.IfdType, t.ID)
 }
@@ -41,6 +65,9 @@ func (t Entry) Size() uint32 {
 
 // IsEmbedded checks inline-value eligibility for common TIFF/EXIF types.
 func (t Entry) IsEmbedded() bool {
+	if t.embedded {
+		return true
+	}
 	switch t.Type {
 	case TypeByte, TypeASCII, TypeUndefined, TypeASCIINoNul:
 		return t.UnitCount <= 4
@@ -65,9 +92,14 @@ func (t Entry) IsValid() bool {
 	return t.Type.IsValid()
 }
 
-// EmbeddedValue writes the packed value bytes (up to 4 bytes) into dst.
+// EmbeddedValue writes the packed value bytes into dst: the low 4 bytes from
+// ValueOffset and, when dst has room, the high 4 bytes from valueHigh (BigTIFF
+// 8-byte inline values). Callers pass an 8-byte dst to read the full value.
 func (t Entry) EmbeddedValue(dst []byte) {
 	t.ByteOrder.PutUint32(dst, t.ValueOffset)
+	if len(dst) >= 8 {
+		t.ByteOrder.PutUint32(dst[4:8], t.valueHigh)
+	}
 }
 
 // EmbeddedShort returns the first embedded SHORT value from ValueOffset.

--- a/meta/exif/tag/type.go
+++ b/meta/exif/tag/type.go
@@ -33,6 +33,11 @@ const (
 	TypeFloat          Type = 11
 	TypeDouble         Type = 12
 
+	// BigTIFF (DNG 1.7) 64-bit types.
+	TypeLong8       Type = 16
+	TypeSignedLong8 Type = 17
+	TypeIfd8        Type = 18
+
 	// Pseudo-types used by parser internals.
 	TypeASCIINoNul Type = 0xf0
 	TypeIfd        Type = 0xf1
@@ -50,6 +55,9 @@ const (
 	TypeFloatSize          = 4
 	TypeDoubleSize         = 8
 	TypeIfdSize            = 4
+	TypeLong8Size          = 8
+	TypeSignedLong8Size    = 8
+	TypeIfd8Size           = 8
 )
 
 var typeIsValidLookup = [256]uint8{
@@ -66,6 +74,9 @@ var typeIsValidLookup = [256]uint8{
 	TypeDouble:         1,
 	TypeASCIINoNul:     1,
 	TypeIfd:            1,
+	TypeLong8:          1,
+	TypeSignedLong8:    1,
+	TypeIfd8:           1,
 }
 
 func (tt Type) Is(t Type) bool {
@@ -101,6 +112,12 @@ func (tt Type) Size() uint8 {
 		return TypeASCIINoNulSize
 	case TypeIfd:
 		return TypeIfdSize
+	case TypeLong8:
+		return TypeLong8Size
+	case TypeSignedLong8:
+		return TypeSignedLong8Size
+	case TypeIfd8:
+		return TypeIfd8Size
 	default:
 		return 0
 	}
@@ -134,6 +151,12 @@ func (tt Type) String() string {
 		return "_ASCII_NO_NUL"
 	case TypeIfd:
 		return "IFD"
+	case TypeLong8:
+		return "LONG8"
+	case TypeSignedLong8:
+		return "SLONG8"
+	case TypeIfd8:
+		return "IFD8"
 	default:
 		return "UNKNOWN"
 	}
@@ -171,7 +194,7 @@ func UsesIFDType(directoryType IfdType, id ID) bool {
 
 // NormalizeType resolves parser pseudo-types for known IFD pointer tags.
 func NormalizeType(directoryType IfdType, id ID, typ Type) Type {
-	if (typ.Is(TypeLong) || typ.Is(TypeUndefined)) && UsesIFDType(directoryType, id) {
+	if (typ.Is(TypeLong) || typ.Is(TypeLong8) || typ.Is(TypeIfd8) || typ.Is(TypeUndefined)) && UsesIFDType(directoryType, id) {
 		return TypeIfd
 	}
 	return typ

--- a/meta/exif/tiff.go
+++ b/meta/exif/tiff.go
@@ -14,6 +14,12 @@ import (
 const (
 	// TiffHeaderLength is 8 bytes
 	TiffHeaderLength = 32
+
+	// maxTiffOffset caps file offsets to 32 bits. BigTIFF offsets are 64-bit on
+	// the wire, but imagemeta stores them as uint32; a container that places an
+	// IFD, value or preview beyond 4 GiB is reported as unsupported (ErrNoExif)
+	// rather than parsed with a truncated offset.
+	maxTiffOffset = 0xFFFFFFFF
 )
 
 // ScanTiffHeader searches for the beginning of the EXIF information. The EXIF is near the
@@ -57,13 +63,31 @@ func ScanTiffHeader(r io.Reader, it imagetype.ImageType) (header meta.ExifHeader
 		}
 
 		// Found Tiff Header
-		firstIfdOffset := byteOrder.Uint32(buf[4:8])
 		tiffHeaderOffset, ok := meta.SafecastIntToUint32(discarded)
 		if !ok {
 			return header, meta.ErrNoExif
 		}
+
+		bigTiff := utils.IsBigTiff(buf)
+		var firstIfdOffset uint32
+		if bigTiff {
+			// BigTIFF header: bytes 4-5 offset size (always 8), 6-7 constant 0,
+			// 8-15 the 8-byte IFD0 offset. Offsets beyond 4 GiB are unsupported.
+			if byteOrder.Uint16(buf[4:6]) != 8 || byteOrder.Uint16(buf[6:8]) != 0 {
+				return header, meta.ErrNoExif
+			}
+			firstIfdOffset64 := byteOrder.Uint64(buf[8:16])
+			if firstIfdOffset64 > maxTiffOffset {
+				return header, meta.ErrNoExif
+			}
+			firstIfdOffset = uint32(firstIfdOffset64)
+		} else {
+			firstIfdOffset = byteOrder.Uint32(buf[4:8])
+		}
+
 		header = meta.NewExifHeader(byteOrder, firstIfdOffset, tiffHeaderOffset, 0, it)
 		header.FirstIfd = tag.IFD0
+		header.BigTIFF = bigTiff
 		return header, nil
 	}
 }

--- a/meta/exif/utils.go
+++ b/meta/exif/utils.go
@@ -194,6 +194,24 @@ func rationalDuration(num uint32, den uint32, unit time.Duration) time.Duration 
 
 // readTagBytes reads data from the underlying stream or parser buffers.
 func (r *Reader) readTagBytes(t tag.Entry, maxBytes uint32) (buf []byte, err error) {
+	// A value packed inline in the entry (BigTIFF fits up to 8 bytes there) is
+	// served from the entry itself, leaving the stream position untouched so the
+	// surrounding sequential reads stay aligned. Classic embedded values are
+	// handled by the callers' own fast paths and do not reach here.
+	if t.IsEmbedded() {
+		size := t.Size()
+		if size == 0 {
+			return nil, nil
+		}
+		if size > 8 {
+			size = 8
+		}
+		if maxBytes > 0 && size > maxBytes {
+			size = maxBytes
+		}
+		t.EmbeddedValue(r.state.buf[:8])
+		return r.state.buf[:size], nil
+	}
 	if err = r.seekToTag(t); err != nil {
 		r.warnTagReadError(t, err, "failed seeking to tag payload")
 		return nil, err
@@ -287,6 +305,16 @@ func (r *Reader) readUint32(directory tag.Directory) (uint32, error) {
 		return 0, err
 	}
 	return directory.ByteOrder.Uint32(buf), nil
+}
+
+// readUint64 reads an 8-byte value from the underlying stream (BigTIFF counts
+// and offsets).
+func (r *Reader) readUint64(directory tag.Directory) (uint64, error) {
+	buf, err := r.fastRead(8)
+	if err != nil || len(buf) < 8 {
+		return 0, err
+	}
+	return directory.ByteOrder.Uint64(buf), nil
 }
 
 func (r *Reader) canonModelID() metacanon.CanonCameraModel {

--- a/meta/exif/values.go
+++ b/meta/exif/values.go
@@ -20,7 +20,7 @@ const (
 // Returned bytes reference parser buffers and are only valid until next read.
 func (r *Reader) parseASCIIValueBytes(t tag.Entry) []byte {
 	if t.IsEmbedded() {
-		t.EmbeddedValue(r.state.buf[:4])
+		t.EmbeddedValue(r.state.buf[:8])
 		return trimNULBuffer(r.state.buf[:t.Size()])
 	}
 	switch t.Type {
@@ -265,7 +265,7 @@ func (r *Reader) parseDisplayBytes(t tag.Entry, maxBytes uint32) []byte {
 		if n > maxBytes {
 			n = maxBytes
 		}
-		t.EmbeddedValue(r.state.buf[:4])
+		t.EmbeddedValue(r.state.buf[:8])
 		return r.state.buf[:n]
 	case t.IsType(tag.TypeUndefined), t.IsType(tag.TypeByte), t.IsType(tag.TypeASCII), t.IsType(tag.TypeASCIINoNul):
 		if maxBytes == 0 {
@@ -323,7 +323,7 @@ func (r *Reader) parseOpaqueBytes(t tag.Entry, maxBytes uint32) []byte {
 	}
 	if t.IsEmbedded() {
 		n := min(t.Size(), maxBytes)
-		t.EmbeddedValue(r.state.buf[:4])
+		t.EmbeddedValue(r.state.buf[:8])
 		return r.state.buf[:n]
 	}
 	buf, err := r.readTagBytes(t, maxBytes)
@@ -427,6 +427,7 @@ func (r *Reader) parseRationalU(t tag.Entry) [2]uint32 {
 	default:
 		return [2]uint32{}
 	}
+	// readTagBytes serves a BigTIFF inline RATIONAL from the 8-byte value field.
 	buf, err := r.readTagBytes(t, 8)
 	if err != nil || len(buf) < 8 {
 		return [2]uint32{}
@@ -463,7 +464,9 @@ func (r *Reader) parseUint16List(t tag.Entry, dst []uint16) int {
 		return 0
 	}
 	n := min(int(t.UnitCount), len(dst))
-	if t.IsEmbedded() {
+	// The fast path packs at most two shorts into ValueOffset; a BigTIFF inline
+	// list of 3-4 shorts (5-8 bytes) is read from the value field via readTagBytes.
+	if t.IsEmbedded() && t.Size() <= 4 {
 		return t.EmbeddedShorts(dst[:n])
 	}
 	maxBytes, ok := meta.SafecastIntToUint32(n * 2)
@@ -501,7 +504,9 @@ func (r *Reader) parseUint32List(t tag.Entry, dst []uint32) int {
 		return 0
 	}
 	n := min(int(t.UnitCount), len(dst))
-	if t.IsEmbedded() {
+	// The fast path packs a single long (or two shorts) into ValueOffset; a
+	// BigTIFF inline pair of longs (8 bytes) is read via readTagBytes below.
+	if t.IsEmbedded() && t.Size() <= 4 {
 		switch t.Type {
 		case tag.TypeLong, tag.TypeIfd:
 			dst[0] = t.EmbeddedLong()
@@ -615,7 +620,7 @@ func (r *Reader) parseByteList(t tag.Entry, dst []byte) int {
 
 	n := min(int(t.UnitCount), len(dst))
 	if t.IsEmbedded() {
-		t.EmbeddedValue(r.state.buf[:4])
+		t.EmbeddedValue(r.state.buf[:8])
 		copy(dst[:n], r.state.buf[:n])
 		return n
 	}

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -87,6 +87,9 @@ type ExifHeader struct {
 	ByteOrder        utils.ByteOrder
 	FirstIfd         tag.IfdType
 	ImageType        imagetype.ImageType
+	// BigTIFF marks a BigTIFF container (DNG 1.7): 8-byte offsets, 20-byte IFD
+	// entries and 64-bit entry counts. Offsets beyond 4 GiB are unsupported.
+	BigTIFF bool
 }
 
 // IsValid returns true if the ExifHeader ByteOrder is not nil and

--- a/meta/utils/byteorder.go
+++ b/meta/utils/byteorder.go
@@ -73,13 +73,28 @@ func (bo ByteOrder) PutUint64(b []byte, v uint64) {
 // CIPA DC-008-2016; JEITA CP-3451D
 // -> http://www.cipa.jp/std/documents/e/DC-008-Translation-2016-E.pdf
 func BinaryOrder(buf []byte) ByteOrder {
-	if IsTiffBigEndian(buf) {
+	if IsTiffBigEndian(buf) || IsBigTiffBigEndian(buf) {
 		return BigEndian
 	}
-	if IsTiffLittleEndian(buf) {
+	if IsTiffLittleEndian(buf) || IsBigTiffLittleEndian(buf) {
 		return LittleEndian
 	}
 	return UnknownEndian
+}
+
+// IsBigTiffLittleEndian reports the BigTIFF (magic 43) little-endian signature.
+func IsBigTiffLittleEndian(buf []byte) bool {
+	return len(buf) >= 4 && string(buf[:4]) == "II+\000"
+}
+
+// IsBigTiffBigEndian reports the BigTIFF (magic 43) big-endian signature.
+func IsBigTiffBigEndian(buf []byte) bool {
+	return len(buf) >= 4 && string(buf[:4]) == "MM\000+"
+}
+
+// IsBigTiff reports whether buf carries either BigTIFF byte-order signature.
+func IsBigTiff(buf []byte) bool {
+	return IsBigTiffLittleEndian(buf) || IsBigTiffBigEndian(buf)
 }
 
 // IsTiffLittleEndian checks the buf for the Tiff LittleEndian Signature


### PR DESCRIPTION
Adds BigTIFF (magic 43) support to the TIFF/EXIF decoder, so BigTIFF DNGs (allowed since DNG spec 1.7) are read for both metadata and embedded previews. Follow-up to the preview-extraction work (#70).

## What is parsed

- 16-byte BigTIFF header (offset-size + reserved word validated), 8-byte IFD0 offset
- 20-byte IFD entries, 64-bit entry counts, 64-bit next-IFD and value/offset fields
- `LONG8` / `SLONG8` / `IFD8` types
- Both byte-order signatures recognized by `imagetype` as `ImageTiff`

## Design: 32-bit value model kept, no API break

Rather than widening `ExifHeader.FirstIfdOffset` / `tag.Entry.ValueOffset` (and the whole offset path) to 64-bit, offsets stay `uint32`:

- 64-bit offsets, counts and IFD pointers are read at their true width and narrowed to `uint32`
- a container that places an IFD, value or preview beyond 4 GiB is reported as unsupported (`ErrNoExif`) instead of parsed with a truncated offset

This keeps the public API and the hot-path `tag.Entry` layout unchanged, and matches the practical ~2 GiB limit of metadata-extractor / Tika.

## Inline values

BigTIFF packs a value of up to 8 bytes inline in the entry (classic TIFF only 4), so a single `RATIONAL`, `DOUBLE`, `LONG8` or a short inline list now lives inline. `tag.Entry` carries the upper 4 bytes plus an `embedded` flag, and `readTagBytes` serves inline values without moving the stream, so every existing value parser reads them correctly. Classic-TIFF paths are untouched (a separate BigTIFF entry decoder; the classic bulk-trusted fast path is unchanged).

## Tests

`bigtiff_test.go` builds synthetic BigTIFF containers and covers: `imagetype` detection, at-offset ASCII, inline ASCII, inline 8-byte `RATIONAL`, an `LONG8` scalar preview offset, end-to-end preview extraction, and rejection of a malformed offset-size header. No regressions in the existing suite.
